### PR TITLE
Dev to Master updating to v1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,28 +33,28 @@ project (conjure_enum
    LANGUAGES CXX
 	HOMEPAGE_URL https://github.com/fix8mt/conjure_enum
    DESCRIPTION "Lightweight C++20 enum and typename reflection"
-   VERSION 1.0.0)
+   VERSION 1.0.2)
 
 # to disable strip:
 # cmake -DBUILD_STRIP_EXE=false ..
 option(BUILD_STRIP_EXE "enable stripping of non-unittest executables" true)
-message("-- Build strip exes: ${BUILD_STRIP_EXE}")
+message("-- Build: strip exes ${BUILD_STRIP_EXE}")
 
 # to disable warnings:
 # cmake -DBUILD_ALL_WARNINGS=false ..
 option(BUILD_ALL_WARNINGS "enable building with all warnings" true)
-message("-- Build with all warnings : ${BUILD_ALL_WARNINGS}")
+message("-- Build: with all warnings ${BUILD_ALL_WARNINGS}")
 
 # to disable building unit tests:
 # cmake -DBUILD_UNITTESTS=false ..
 option(BUILD_UNITTESTS "enable building unit tests" true)
-message("-- Build unit tests: ${BUILD_UNITTESTS}")
+message("-- Build: unit tests ${BUILD_UNITTESTS}")
 
 # to enable clang build profiler:
 # cmake -DBUILD_CLANG_PROFILER=true ..
 # see examples/cbenchmark.sh
 option(BUILD_CLANG_PROFILER "enable clang build profiler" false)
-message("-- Build clang profiler: ${BUILD_CLANG_PROFILER}")
+message("-- Build: clang profiler ${BUILD_CLANG_PROFILER}")
 if(BUILD_CLANG_PROFILER)
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		add_compile_options(-ftime-trace)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ project (conjure_enum
    LANGUAGES CXX
 	HOMEPAGE_URL https://github.com/fix8mt/conjure_enum
    DESCRIPTION "Lightweight C++20 enum and typename reflection"
-   VERSION 1.0.2)
+   VERSION 1.1.0)
+
+message("${CMAKE_PROJECT_NAME} version ${CMAKE_PROJECT_VERSION}")
 
 # to disable strip:
 # cmake -DBUILD_STRIP_EXE=false ..

--- a/README.md
+++ b/README.md
@@ -1495,7 +1495,7 @@ Our testing shows a reduction in overall compile times. All enums using `conjure
 #define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
 ```
 You can enable all optimizations described above by defining `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` _before_ you include `conjure_enum.hpp`.
-This will is the equivalent of defining:
+This is the equivalent of defining:
 ```c++
 #define FIX8_CONJURE_ENUM_MINIMAL
 #define FIX8_CONJURE_ENUM_IS_CONTINUOUS

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
-> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most $`2log_2(N)+O(1)`$ comparisons.
+> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most $` 2log_2(N)+O(1) `$ comparisons.
 > If the array is _not_ sorted, complexity is linear.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };

--- a/README.md
+++ b/README.md
@@ -1547,7 +1547,7 @@ struct FIX8::enum_range<range_test>
 static_assert(conjure_enum<range_test>::get_enum_min_value() == 0);
 static_assert(conjure_enum<range_test>::get_enum_max_value() == 7);
 ```
-#### ii.1 `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
+#### ii.a `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
 For convenience, two macros are provided to make it easier to set custom ranges.
 ```c++
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,min_int,max_int)...
@@ -1587,6 +1587,12 @@ _output_
 0/7
 0/7
 ```
+
+### iv. Which enum limit approach to use
+Compilation times increase with the number of enums that use `conjure_enum` in any compilation unit.
+- For a simple project with few enums, there is probably no need to set any limits.
+- Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros
+- Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`
 
 ## b) Choosing the minimal build
 ```c++

--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,11 @@ FIX8_CONJURE_ENUM_SET_RANGE(numbers::first, numbers::eighth)
 Another approach to setting a custom range for an enum is to alias the first and last enum values in your enum definition
 using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the enum range.
 You can set either, both or neither. A range value not set will default to the `FIX8_CONJURE_ENUM_MIN_VALUE` or `FIX8_CONJURE_ENUM_MAX_VALUE`.
+
+> [!WARN]
+> For unscoped enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined, due to the open scoping of unscoped
+> enums. It is therefore recommended to only use this feature with scoped enumns.
+
 For example:
 ```c++
 enum class range_test { first, second, third, fourth, fifth, sixth, seventh, eighth, ce_first=first, ce_last=eighth };

--- a/README.md
+++ b/README.md
@@ -1453,8 +1453,6 @@ int main(void)
 {
    for(const auto& [a, b] : conjure_enum<component>::entries)
       std::cout << conjure_enum<component>::enum_to_int(a) << ' ' << b << '\n';
-   for(const auto& a : conjure_enum<component>::names)
-      std::cout << a << '\n';
    std::cout << static_cast<int>(conjure_enum<component>::string_to_enum("component::path").value()) << '\n';
    std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_max_value() << '\n';
    return 0;
@@ -1473,16 +1471,6 @@ $ ./statictest
 7 component::path
 8 component::query
 9 component::fragment
-component::scheme
-component::authority
-component::userinfo
-component::user
-component::password
-component::host
-component::port
-component::path
-component::query
-component::fragment
 7
 0/9
 $
@@ -1581,7 +1569,102 @@ would run the script from the `conjure_enum` directory as follows:
 ```bash
 ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh
 ```
-The results will be printed to the screen.
+The results will be printed to the screen. For example:
+<details><summary><i>shell output</i></summary>
+<p>
+<pre>
+Processing all files and saving to 'cbenchmark.dat'...
+  done in 0.0s. Run 'ClangBuildAnalyzer --analyze cbenchmark.dat' to analyze it.
+Analyzing build trace from 'cbenchmark.dat'...
+**** Time summary:
+Compilation (2 times):
+  Parsing (frontend):            0.7 s
+  Codegen & opts (backend):      0.0 s
+
+**** Files that took longest to parse (compiler frontend):
+   662 ms: build_clang/CMakeFiles/cbenchmark.dir/examples/cbenchmark.cpp.o
+
+**** Files that took longest to codegen (compiler backend):
+    18 ms: build_clang/CMakeFiles/cbenchmark.dir/examples/cbenchmark.cpp.o
+
+**** Templates that took longest to instantiate:
+   290 ms: FIX8::conjure_enum<std::errc> (1 times, avg 290 ms)
+   140 ms: FIX8::conjure_enum<std::errc>::_entries<0UL, 1UL, 2UL, 3UL, 4UL, 5UL... (1 times, avg 140 ms)
+    82 ms: FIX8::conjure_enum<std::errc>::_values<0UL, 1UL, 2UL, 3UL, 4UL, 5UL,... (1 times, avg 82 ms)
+     8 ms: FIX8::conjure_enum<std::errc>::_sorted_entries (1 times, avg 8 ms)
+     7 ms: std::reverse_iterator<std::_Bit_iterator> (1 times, avg 7 ms)
+     6 ms: std::sort<std::tuple<std::errc, std::basic_string_view<char>> *, boo... (1 times, avg 6 ms)
+     6 ms: std::__sort<std::tuple<std::errc, std::basic_string_view<char>> *, _... (1 times, avg 6 ms)
+     6 ms: std::reverse_iterator<std::_Bit_const_iterator> (1 times, avg 6 ms)
+     5 ms: std::unordered_map<int, int> (1 times, avg 5 ms)
+     5 ms: std::__introsort_loop<std::tuple<std::errc, std::basic_string_view<c... (1 times, avg 5 ms)
+     3 ms: std::array<std::tuple<std::errc, std::basic_string_view<char>>, 47> (1 times, avg 3 ms)
+     3 ms: std::_Hashtable<int, std::pair<const int, int>, std::allocator<std::... (1 times, avg 3 ms)
+     3 ms: FIX8::conjure_enum<std::errc>::enum_to_string (1 times, avg 3 ms)
+     3 ms: std::tuple<std::basic_string_view<char>, char, std::basic_string_vie... (1 times, avg 3 ms)
+     2 ms: std::__unguarded_partition_pivot<std::tuple<std::errc, std::basic_st... (1 times, avg 2 ms)
+     2 ms: std::tuple<std::errc, std::basic_string_view<char>> (1 times, avg 2 ms)
+     2 ms: std::tuple<std::errc, std::basic_string_view<char>>::tuple<const std... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::inappropriate_i... (1 times, avg 2 ms)
+     2 ms: std::__move_median_to_first<std::tuple<std::errc, std::basic_string_... (1 times, avg 2 ms)
+     2 ms: std::iter_swap<std::tuple<std::errc, std::basic_string_view<char>> *... (1 times, avg 2 ms)
+     2 ms: std::__partial_sort<std::tuple<std::errc, std::basic_string_view<cha... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::too_many_files_... (1 times, avg 2 ms)
+     2 ms: std::__heap_select<std::tuple<std::errc, std::basic_string_view<char... (1 times, avg 2 ms)
+     2 ms: std::tuple<std::basic_string_view<char>, char, std::basic_string_vie... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::no_such_file_or... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::operation_not_p... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::no_message_avai... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::operation_would... (1 times, avg 2 ms)
+     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::no_space_on_dev... (1 times, avg 2 ms)
+     2 ms: std::__make_heap<std::tuple<std::errc, std::basic_string_view<char>>... (1 times, avg 2 ms)
+
+**** Template sets that took longest to instantiate:
+   290 ms: FIX8::conjure_enum<$> (1 times, avg 290 ms)
+   140 ms: FIX8::conjure_enum<$>::_entries<$> (1 times, avg 140 ms)
+    82 ms: FIX8::conjure_enum<$>::_values<$> (1 times, avg 82 ms)
+    78 ms: FIX8::conjure_enum<$>::_enum_name<$> (47 times, avg 1 ms)
+    55 ms: FIX8::conjure_enum<$>::_is_valid<$> (72 times, avg 0 ms)
+    38 ms: FIX8::conjure_enum<$>::_get_name<$> (47 times, avg 0 ms)
+    15 ms: std::tuple<$>::tuple<$> (20 times, avg 0 ms)
+    13 ms: std::reverse_iterator<$> (2 times, avg 6 ms)
+     8 ms: FIX8::conjure_enum<$>::_sorted_entries (1 times, avg 8 ms)
+     7 ms: std::basic_string<$> (5 times, avg 1 ms)
+     6 ms: std::sort<$> (1 times, avg 6 ms)
+     6 ms: std::__sort<$> (1 times, avg 6 ms)
+     5 ms: std::tuple<$> (2 times, avg 2 ms)
+     5 ms: std::_Hashtable<$> (2 times, avg 2 ms)
+     5 ms: std::unordered_map<$> (1 times, avg 5 ms)
+     5 ms: std::__introsort_loop<$> (1 times, avg 5 ms)
+     4 ms: std::array<$> (2 times, avg 2 ms)
+     4 ms: std::basic_string<$>::_M_construct<$> (4 times, avg 1 ms)
+     3 ms: FIX8::conjure_enum<$>::enum_to_string (1 times, avg 3 ms)
+     3 ms: std::__and_<$> (4 times, avg 0 ms)
+     2 ms: std::__unguarded_partition_pivot<$> (1 times, avg 2 ms)
+     2 ms: std::__move_median_to_first<$> (1 times, avg 2 ms)
+     2 ms: std::iter_swap<$> (1 times, avg 2 ms)
+     2 ms: std::__partial_sort<$> (1 times, avg 2 ms)
+     2 ms: std::copy<$> (3 times, avg 0 ms)
+     2 ms: std::__heap_select<$> (1 times, avg 2 ms)
+     2 ms: std::_Tuple_impl<$> (2 times, avg 1 ms)
+     2 ms: std::__make_heap<$> (1 times, avg 2 ms)
+     1 ms: std::optional<$> (1 times, avg 1 ms)
+     1 ms: std::to_array<$> (1 times, avg 1 ms)
+
+**** Functions that took longest to compile:
+     2 ms: test_conjure_enum(std::errc) (/home/davidd/prog/conjure_enum_tclass/examples/cbenchmark.cpp)
+
+**** Function sets that took longest to compile / optimize:
+
+**** Expensive headers:
+181 ms: /home/davidd/prog/conjure_enum_tclass/include/fix8/conjure_enum.hpp (included 1 times, avg 181 ms), included via:
+  1x: <direct include>
+
+173 ms: /usr/include/c++/14/system_error (included 1 times, avg 173 ms), included via:
+  1x: <direct include>
+
+  done in 0.0s.
+</pre></p></details>
 
 ---
 # 8. Compiler support

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ for the bit positions (and names).
 > - Continuous
 > - The last value must be less than the count of enumerations
 >
-> We decided on these restrictions for both simplicity and practicality - bitsets only really make sense when represented in this manner.
+> We decided on these restrictions for both simplicity and practicality - bitsets only really make sense when represented in this manner; also...
 >
 > - This implementation is limited to 64 bits
 
@@ -1145,6 +1145,7 @@ constexpr std::string to_string(char zero='0', char one='1') const;
 
 template<bool showbase=true, bool uppercase=false>
 constexpr std::string to_hex_string() const;
+
 constexpr std::string to_hex_string() const;
 ```
 Inserts default string representation into `std::ostream`.<br>
@@ -1156,12 +1157,14 @@ the string with `0x` or `0X`; optionally specify `uppercase` which will set the 
 enum_bitset<numbers> ec(numbers::one,numbers::three,numbers::six);
 std::cout << ec << '\n';
 std::cout << ec.to_string('-', '+') << '\n';
+std::cout << ec.to_hex_string() << '\n';
 std::cout << ec.to_hex_string<true, true>() << '\n';
 ```
 _output_
 ```CSV
 0001001010
 ---+--+-+-
+0x4a
 0X4A
 ```
 ### iv. `for_each`, `for_each_n`

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ enum class numbers { zero, one, two, three, four, five, six, seven, eight, nine 
 >   requires std::same_as<T, std::decay_t<T>>;
 >   requires std::is_enum_v<T>;
 >};
-```
+>```
 
 ## a) `enum_to_string`
 ```c++
@@ -927,7 +927,7 @@ for the bit positions (and names).
 >   requires conjure_enum<T>::get_actual_enum_max_value() < conjure_enum<T>::count();
 >   requires std::bit_ceil(static_cast<unsigned>(conjure_enum<T>::get_actual_enum_max_value())) >= conjure_enum<T>::count();
 >};
-```
+>```
 
 ## a) Creating an `enum_bitset`
 ```c++

--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,7 @@ All of the standard accessors and mutators are supported.
 | `to_ullong` | convert to `unsigned long long` |
 | `count` | count of bits on |
 | `size` | number of bits in bitset |
-| `operator[]` | set or test bit at position |
+| `operator[]` | set or test bit at position or enum value |
 | `any` | return `true` if any bit is on |
 | `all` | return `true` if all bits are on |
 | `none` | return `true` if no bits are on |
@@ -1055,6 +1055,10 @@ std::cout << std::boolalpha << eb.all_of(numbers::zero,numbers::nine) << '\n';
 std::cout << eb << '\n';
 eb.reset(numbers::nine)
 std::cout << ec << '\n';
+eb.reset();
+eb[2] = true;
+eb[numbers::three] = true;
+std::cout << eb << '\n';
 ```
 _output_
 ```
@@ -1065,6 +1069,7 @@ true
 true
 1000000001
 0000000001
+0000001100
 ```
 ## d) Other functions
 ### i. `operator bool`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 > Even better in [full read view](./README.md) of this page.
 >
 > For the latest cutting edge changes, see the [dev branch](https://github.com/fix8mt/conjure_enum/tree/dev).
+> You can view the changes [here](https://github.com/fix8mt/conjure_enum/compare/master..dev).
 
 ---
 # 2. Introduction

--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,7 @@ All of the standard accessors and mutators are supported.
 | `to_ullong` | convert to `unsigned long long` |
 | `count` | count of bits on |
 | `size` | number of bits in bitset |
-| `operator[]` | test bit at position |
+| `operator[]` | set or test bit at position |
 | `any` | return `true` if any bit is on |
 | `all` | return `true` if all bits are on |
 | `none` | return `true` if no bits are on |

--- a/README.md
+++ b/README.md
@@ -1753,7 +1753,7 @@ Compilation (2 times):
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
 | [clang](https://clang.llvm.org/cxx_status.html) | `15`, `16`, `17`, `18`| Catch2 needs `cxx_std_20` in `15` | `<= 14` |
-| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.10.5`| `<= 16.9`|
+| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.0`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
 # 9. Compiler issues

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ Another approach to setting a custom range for an enum is to alias the first and
 using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the enum range.
 You can set either, both or neither. A range value not set will default to the `FIX8_CONJURE_ENUM_MIN_VALUE` or `FIX8_CONJURE_ENUM_MAX_VALUE`.
 
-> [!WARN]
+> [!WARNING]
 > For unscoped enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined, due to the open scoping of unscoped
 > enums. It is therefore recommended to only use this feature with scoped enumns.
 

--- a/README.md
+++ b/README.md
@@ -1482,15 +1482,35 @@ If your enum(s) are continuous (no gaps) you can enable this compiler optimizati
 by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`.
 Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
 
-## d) Class `conjure_enum` is not constructible
+## d) Anonymous enum optimization
+```c++
+#define FIX8_CONJURE_ENUM_NO_ANON
+```
+If your enum(s) are not within any anonymous namespaces (rarely used for this purpose), you can enable this compiler optimization
+by defining `FIX8_CONJURE_ENUM_NO_ANON` _before_ you include `conjure_enum.hpp`.
+Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+
+## e) Enable all optimizations
+```c++
+#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+```
+You can enable all optimizations described above by defining `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` _before_ you include `conjure_enum.hpp`.
+This will is the equivalent of defining:
+```c++
+#define FIX8_CONJURE_ENUM_MINIMAL
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#define FIX8_CONJURE_ENUM_NO_ANON
+```
+
+## f) Class `conjure_enum` is not constructible
 All methods in this class are _static_. You cannot instantiate an object of this type. The same goes for `conjure_type`.
 
-## e) It's not _real_ reflection
+## g) It's not _real_ reflection
 This library provides a workaround (hack :smirk:) to current limitations of C++. There are proposals out there for future versions of the language that will provide proper reflection.
 See [Reflection TS](https://en.cppreference.com/w/cpp/experimental/reflect) and [Reflection for C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html)
 for examples of some of these.
 
-## f) Use of `std::string_view`
+## h) Use of `std::string_view`
 All of the generated static strings and generated static tables obtained by `std::source_location` use the library defined `fixed_string`. No string copying is done at runtime, resulting in
 a single static string in your application. All `conjure_enum` methods that return strings _only_ return `std::string_view`.
 To demonstrate this, lets look at the supplied test application `statictest`:
@@ -1611,7 +1631,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## g) Compilation profiling (Clang)
+## i) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake

--- a/README.md
+++ b/README.md
@@ -402,7 +402,28 @@ userinfo  component::userinfo
 static constexpr std::array<std::tuple<std::string_view, std::string_view>, std::size_t> rev_scoped_entries;
 ```
 Same as `scoped_entries` except reversed, sorted by scoped name. Use to lookup unscoped name.
-## m) `contains`
+## m) `index`
+```c++
+static constexpr std::optional<size_t> index(T value);
+template<T e>
+static constexpr std::optional<size_t> index();
+```
+Returns the index (position in 0 based array of values) of the supplied enum value `std::optional<size_t>`. Empty if value was not valid. Use `std::optional<T>::value_or()` to set an error value
+and avoid throwing an exception.
+```c++
+std::cout << conjure_enum<component>::index(component::password).value() << '\n';
+std::cout << conjure_enum<component>::index(component(100)).value_or(100) << '\n';
+std::cout << conjure_enum<component>::index<component::password>().value() << '\n';
+std::cout << conjure_enum<component>::index<component(100)>().value_or(100) << '\n';
+```
+_output_
+```CSV
+4
+100 <-- invalid, error value
+4
+100 <-- invalid, error value
+```
+## n) `contains`
 ```c++
 static constexpr bool contains(T value);
 static constexpr bool contains(std::string_view str);
@@ -417,7 +438,7 @@ _output_
 true
 false
 ```
-## n) `for_each`, `for_each_n`
+## o) `for_each`, `for_each_n`
 ```c++
 template<typename Fn, typename... Args>
 requires std::invocable<Fn&&, T, Args...>
@@ -521,7 +542,7 @@ _output_
 ```CSV
 160
 ```
-## o) `dispatch`
+## p) `dispatch`
 ```c++
 template<typename Fn>
 static constexpr bool tuple_comp(const std::tuple<T, Fn>& pl, const std::tuple<T, Fn>& pr);
@@ -620,7 +641,7 @@ _output_
 6000
 1015
 ```
-## p) `is_scoped`
+## q) `is_scoped`
 ```c++
 struct is_scoped : std::integral_constant<bool, requires
    { requires !std::is_convertible_v<T, std::underlying_type_t<T>>; }>{};
@@ -635,7 +656,7 @@ _output_
 true
 false
 ```
-## q) `is_valid`
+## r) `is_valid`
 ```c++
 template<T e>
 static constexpr bool is_valid();
@@ -650,7 +671,7 @@ _output_
 true
 false
 ```
-## r) `type_name`
+## s) `type_name`
 ```c++
 static constexpr std::string_view type_name();
 ```
@@ -664,7 +685,7 @@ _output_
 component
 component1
 ```
-## s) `remove_scope` ![](assets/notminimalred.svg)
+## t) `remove_scope` ![](assets/notminimalred.svg)
 ```c++
 static constexpr std::string_view remove_scope(std::string_view what);
 ```
@@ -678,7 +699,7 @@ _output_
 path
 path
 ```
-## t) `add_scope` ![](assets/notminimalred.svg)
+## u) `add_scope` ![](assets/notminimalred.svg)
 ```c++
 static constexpr std::string_view add_scope(std::string_view what);
 ```
@@ -692,7 +713,7 @@ _output_
 component::path
 path
 ```
-## u) `has_scope` ![](assets/notminimalred.svg)
+## v) `has_scope` ![](assets/notminimalred.svg)
 ```c++
 static constexpr bool has_scope(std::string_view what);
 ```
@@ -708,7 +729,7 @@ true
 false
 false
 ```
-## v) `iterators`
+## w) `iterators`
 ```c++
 static constexpr auto cbegin();
 static constexpr auto cend();
@@ -735,7 +756,7 @@ _output_
 8 numbers::eight
 9 numbers::nine
 ```
-## w) `iterator_adaptor`
+## x) `iterator_adaptor`
 ```c++
 template<valid_enum T>
 struct iterator_adaptor;
@@ -758,7 +779,7 @@ _output_
 8
 9
 ```
-## x) `front, back`
+## y) `front, back`
 ```c++
 static constexpr auto front();
 static constexpr auto back();
@@ -775,7 +796,7 @@ _output_
 0 numbers::zero
 9 numbers::nine
 ```
-## y) `ostream_enum_operator`
+## z) `ostream_enum_operator`
 ```c++
 template<typename CharT, typename Traits=std::char_traits<CharT>, valid_enum T>
 constexpr std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, T value);
@@ -797,7 +818,7 @@ _output_
 "host"
 "100"
 ```
-## z) `epeek, tpeek`
+## A) `epeek, tpeek`
 ```c++
 static consteval const char *tpeek();
 template<T e>
@@ -817,7 +838,7 @@ static consteval const char* FIX8::conjure_enum<T>::tpeek() [with T = component]
 static consteval const char* FIX8::conjure_enum<T>::epeek() [with T e = component::path; T = component]
 ```
 
-## aa) `get_enum_min_value` and `get_enum_max_value`
+## B) `get_enum_min_value` and `get_enum_max_value`
 ```c++
 static constexpr int get_enum_min_value();
 static constexpr int get_enum_max_value();
@@ -1257,11 +1278,11 @@ target_include_directories(myproj PRIVATE ${conjure_enum_SOURCE_DIR}/include)
 ## d) Reporting issues
 Raise an [issue](https://github.com/fix8mt/conjure_enum/issues) on the github page.
 The executable `srcloctest` should be built when you build the package by default. This application
-does not use any of the `conjure_enum` library and is designed to report on how your compiler handles `std::source_location`.
+does not use any of the `conjure_enum` library and is designed to report how your compiler handles `std::source_location`.
 The actual output is implementation dependent. See [Results of `source_location`](reference/source_location.md) for implementation specific `std::source_location` results.
 You should attach the output of this application with your issue.
 > [!TIP]
-> Passing the switch `-m` causes `srcloctest` to generate github markdown which you can paste directly into the issue.
+> Use the `-m` switch with `srcloctest` to generate github markdown which you can paste directly into the issue.
 
 ```C++
 $ ./srcloctest

--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,7 @@ ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ex
 The results will be printed to the screen. For example:
 <details><summary><i>output</i></summary>
 <p>
+
 ```CSV
 Processing all files and saving to 'cbenchmark.dat'...
   done in 0.0s. Run 'ClangBuildAnalyzer --analyze cbenchmark.dat' to analyze it.
@@ -1677,6 +1678,7 @@ Compilation (2 times):
 
   done in 0.0s.
 ```
+
 </p></details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -615,7 +615,9 @@ The second version of each of the above is intended to be used when using a memb
 You can also use `std::bind` to bind the this pointer and any parameter placeholders when declaring your array.
 If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 
-If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
+> [!TIP]
+> If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
+
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
 > The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most&ensp; $2log_2(N)+O(1)$ &ensp;comparisons.

--- a/README.md
+++ b/README.md
@@ -427,16 +427,20 @@ _output_
 ```c++
 static constexpr bool contains(T value);
 static constexpr bool contains(std::string_view str);
+template<T e>
+static constexpr bool contains();
 ```
 Returns `true` if the enum contains the given value or string.
 ```c++
 std::cout << std::format("{}\n", conjure_enum<component>::contains(component::path));
 std::cout << std::format("{}\n", conjure_enum<component1>::contains("nothing"));
+std::cout << std::format("{}\n", conjure_enum<component>::contains<component::path>());
 ```
 _output_
 ```CSV
 true
 false
+true
 ```
 ## o) `for_each`, `for_each_n`
 ```c++

--- a/README.md
+++ b/README.md
@@ -1615,8 +1615,8 @@ using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the 
 You can set either, both or neither. A range value not set will default to the `FIX8_CONJURE_ENUM_MIN_VALUE` or `FIX8_CONJURE_ENUM_MAX_VALUE`.
 
 > [!WARNING]
-> With _unscoped_ enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined in any translation unit (ODR), due to the open scoping of unscoped
-> enums. It is therefore recommended to only use this feature with scoped enums.
+> With _unscoped_ enums, there can only be one enum type with `ce_first` and `ce_last` defined in any translation unit (ODR).
+> It is therefore recommended to only use this feature with scoped enums.
 
 For example:
 ```c++

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 |2|[`conjure_enum` API and Examples](#3-api-and-examples-using-conjure_enum)| General examples|
 |3|[`enum_bitset` API and Examples](#4-api-and-examples-using-enum_bitset)| Enhanced enum aware `std::bitset`|
 |4|[`conjure_type` API and Examples](#5-api-and-examples-using-conjure_type)| Any type string extractor|
-|5|[`fixed_string` API](#6-api-for-fixed-string)| Fixed string|
+|5|[`fixed_string` API](#6-api-for-fixed_string)| Statically stored fixed string|
 |6|[Building](#7-building)| How to build or include|
 |7|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
 |8|[Notes](#8-notes)| Notes on the implementation, limits, etc|

--- a/README.md
+++ b/README.md
@@ -1429,10 +1429,10 @@ This implementation is header only. Apart from standard C++20 includes there are
 [Catch2](https://github.com/catchorg/Catch2.git) is used for the built-in unit tests.
 
 ## a) Obtaining the source, building the unittests and examples
-### i. Build platofrm
+### i. Build platform
 #### \*nix based environments
 To clone and default build the test app, unit tests and the benchmark:
-```bash
+```Shell
 git clone https://github.com/fix8mt/conjure_enum.git
 cd conjure_enum
 mkdir build
@@ -1450,27 +1450,27 @@ The package is also available on [vckpg](https://vcpkg.io/en/package/conjure-enu
 
 ### ii. Default compiler warnings
 By default all warnings are enabled. To prevent this, pass the following to cmake:
-```cmake
+```Shell
 cmake -DBUILD_ALL_WARNINGS=false ..
 ```
 ### iii. Default unit tests
 By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
-```cmake
+```Shell
 cmake -DBUILD_UNITTESTS=false ..
 ```
 ### iv. Default executable stripping
 To disable stripping of the executables:
-```cmake
+```Shell
 cmake -DBUILD_STRIP_EXE=false ..
 ```
 ### v. Clang compilation profiling
 To enable clang compilation profiling:
-```cmake
+```Shell
 cmake -DBUILD_CLANG_PROFILER=true ..
 ```
 ## b) Using in your application with cmake
 In `CMakeLists.txt` set your include path to:
-```cmake
+```Shell
 include_directories([conjure_enum directory]/include)
 # e.g.
 set(cjedir /home/dd/prog/conjure_enum)

--- a/README.md
+++ b/README.md
@@ -888,6 +888,7 @@ for the bit positions (and names).
 > - Your enum sequence _must_ be 0 based
 > - Continuous
 > - The last value must be less than the count of enumerations
+>
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ static constexpr std::optional<size_t> index(T value);
 template<T e>
 static constexpr std::optional<size_t> index();
 ```
-Returns the index (position in 0 based array of values) of the supplied enum value `std::optional<size_t>`. Empty if value was not valid. Use `std::optional<T>::value_or()` to set an error value
+Returns the index (position in 0 based array of values) of the supplied enum value as an `std::optional<size_t>`.
+Empty if value was not valid. Use `std::optional<T>::value_or()` to set an error value
 and avoid throwing an exception.
 ```c++
 std::cout << conjure_enum<component>::index(component::password).value() << '\n';

--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,8 @@ Additional methods
 | :--- | :--- |
 | `set` | set all specified bits, templated |
 | `reset` | reset all specified bits, templated |
+| `rotl` | rotate underlying left specified times|
+| `rotr` | rotate underlying right specified times|
 | `any_of` | test for one or more bits, templated, function, types and underlyings |
 | `all_of` | test for all specified bits, templated, function, types and underlyings |
 | `none_of` | test for all specified bits set to off, templated, function, types and underlyings |
@@ -1092,6 +1094,7 @@ eb.reset();
 eb[2] = true;
 eb[numbers::three] = true;
 std::cout << eb << '\n';
+std::cout << eb.rotr(1) << '\n';
 ```
 _output_
 ```
@@ -1103,6 +1106,7 @@ true
 1000000001
 0000000001
 0000001100
+0000011000
 ```
 ## d) Other functions
 ### i. `operator bool`

--- a/README.md
+++ b/README.md
@@ -1677,7 +1677,7 @@ Compilation (2 times):
 
   done in 0.0s.
 ```
-</pre></p></details>
+</p></details>
 
 ---
 # 8. Compiler support

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,17 @@ _output_
 ```CSV
 exception: twenty
 ```
+You can also create an `enum_bitset` from a `std::bitset` of the same number of bits.
+```c++
+std::bitset<10> bs{1 << 1 | 1 << 3 | 1 << 6};
+enum_bitset<numbers> ed(bs);
+std::cout << ed << '\n';
+```
+_output_
+```CSV
+0001001010
+```
+
 ## b) Standard bit operators
 All of the standard operators are supported. Assignment operators return a `enum_bitset&`, non-assignment operators return a `enum_bitset`.
 
@@ -1109,7 +1120,23 @@ _output_
 0001001111
 ```
 
-### ii. `std::ostream& operator<<`, `to_string`
+### ii. `operator std::bitset<N>()`
+```c++
+constexpr operator std::bitset<N>() const;
+```
+Cast an `enum_bitset` to a `std::bitset` with the same number of bits.
+
+```c++
+enum_bitset<numbers> ec(numbers::one,numbers::three,numbers::six);
+std::bitset<10> bs{ec};
+std::cout << bs << '\n';
+```
+_output_
+```CSV
+0001001010
+```
+
+### iii. `std::ostream& operator<<`, `to_string`
 ```c++
 friend constexpr std::ostream& operator<<(std::ostream& os, const enum_bitset& what);
 constexpr std::string to_string(char zero='0', char one='1') const;
@@ -1127,7 +1154,7 @@ _output_
 0001001010
 ---+--+-+-
 ```
-### iii. `for_each`, `for_each_n`
+### iv. `for_each`, `for_each_n`
 ```c++
 template<typename Fn, typename... Args>
 requires std::invocable<Fn&&, T, Args...>
@@ -1187,7 +1214,7 @@ numbers::two
 numbers::five
 ```
 
-### iv. Using `conjure_enum::dispatch` with `enum_bitset`
+### v. Using `conjure_enum::dispatch` with `enum_bitset`
 Using an `enum_bitset` wth `conjure_enum::dispatch` can be a convenient way of iterating through a set of bits to call specific functions using `for_each`. The following demonstrates this:
 ```c++
 const auto dd3
@@ -1216,6 +1243,25 @@ _output_
 3103
 not found: 5
 ```
+
+### vi. `get_underlying`
+```c++
+constexpr U get_underlying() const;
+```
+Returns the underlying integral bitset object.
+
+### vii. `get_underlying_bit_size`
+```c++
+constexpr int get_underlying_bit_size() const
+```
+Returns the number of bits that the underlying integral contains. Will always be a power of 2. The number of bits may be larger
+than the count of bits.
+
+### viii. `get_unused_bit_mask`
+```c++
+constexpr U get_unused_bit_mask() const;
+```
+Returns a bit mask that would mask off the unused bits of the underlying integral.
 
 ---
 # 5. API and Examples using `conjure_type`

--- a/README.md
+++ b/README.md
@@ -923,7 +923,6 @@ for the bit positions (and names).
 >   requires conjure_enum<T>::is_continuous();
 >   requires conjure_enum<T>::get_actual_enum_min_value() == 0;
 >   requires conjure_enum<T>::get_actual_enum_max_value() < conjure_enum<T>::count();
->   requires std::bit_ceil(static_cast<unsigned>(conjure_enum<T>::get_actual_enum_max_value())) >= conjure_enum<T>::count();
 >};
 >```
 

--- a/README.md
+++ b/README.md
@@ -864,6 +864,7 @@ for the bit positions (and names).
 > [!WARNING]
 > Your enum _must_ be continuous. The last value must be less than the count of enumerations.
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
+
 > [!IMPORTANT]
 > You must include
 ```C++

--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ static constexpr int get_actual_enum_max_value();
 ```
 The first two functions return the min and max enum range for the specified enum. If you have specialised `enum_range` then these values
 will be reported (see below).
+
 The second two functions return the actual min and max enum values as ints for the specified enum.
 ```c++
 std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_min_value() << '\n';
@@ -1450,6 +1451,9 @@ Provides an `ostream` insertor.
 # 7. Building
 This implementation is header only. Apart from standard C++20 includes there are no external dependencies needed in your application.
 [Catch2](https://github.com/catchorg/Catch2.git) is used for the built-in unit tests.
+> [!NOTE]
+> The unit test source files [unittests.cpp](utests/unittests.cpp) and [edgetests.cpp](utests/edgetests.cpp) contain additional examples for all
+> the APIs.
 
 ## a) Obtaining the source, building the unittests and examples
 ### i. Build platform
@@ -1651,6 +1655,7 @@ For convenience, two macros are provided to make it easier to set custom ranges 
 #define FIX8_CONJURE_ENUM_SET_RANGE(min_enum,max_enum)...
 ```
 The first macro takes an enum typename followed by a lower and upper int range value.
+
 The second macro takes a lower and upper enum value. For example:
 ```c++
 FIX8_CONJURE_ENUM_SET_RANGE_INTS(numbers, 0, 7)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ enum component1 { scheme, authority, userinfo, user, password, host, port, path=
 enum class numbers { zero, one, two, three, four, five, six, seven, eight, nine };
 ```
 
+> [!IMPORTANT]
+> Your type _must_ be an enum, satisfying
+> ```C++
+>template<typename T>
+>concept valid_enum = requires(T)
+>{
+>   requires std::same_as<T, std::decay_t<T>>;
+>   requires std::is_enum_v<T>;
+>};
+> ```
+
 ## a) `enum_to_string`
 ```c++
 static constexpr std::string_view enum_to_string(T value, bool noscope=false);

--- a/README.md
+++ b/README.md
@@ -1592,6 +1592,7 @@ _output_
 Compilation times increase with the number of enums that use `conjure_enum` in any compilation unit.
 1. For a simple project with few enums, there is probably no need to set any limits.
 1. Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros
+1. Where the enum is unscoped then use `enum_range` or one of the convenience macros
 1. Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`, or 2.
 
 ## b) Choosing the minimal build

--- a/README.md
+++ b/README.md
@@ -1068,6 +1068,10 @@ Additional methods
 | `reset` | reset all specified bits, templated |
 | `rotl` | rotate underlying left specified times|
 | `rotr` | rotate underlying right specified times|
+| `countl_zero` | counts number of consecutive underlying `0` bits, starting from the most significant bit |
+| `countl_one` | counts number of consecutive underlying `1` bits, starting from the most significant bit |
+| `countr_zero` | counts number of consecutive underlying `0` bits, starting from the least significant bit |
+| `countr_one` | counts number of consecutive underlying `1` bits, starting from the least significant bit |
 | `any_of` | test for one or more bits, templated, function, types and underlyings |
 | `all_of` | test for all specified bits, templated, function, types and underlyings |
 | `none_of` | test for all specified bits set to off, templated, function, types and underlyings |

--- a/README.md
+++ b/README.md
@@ -1146,7 +1146,7 @@ template<bool showbase=true, bool uppercase=false>
 constexpr std::string to_hex_string() const;
 ```
 Inserts default string representation into `std::ostream`.<br>
-Returns a `std::string` representation of the bitset. Optionally specify which characters to use for `0` and `1`.
+Returns a `std::string` representation of the bitset. Optionally specify which characters to use for `0` and `1`.<br>
 Returns a `std::string` representation of the bitset in hex format. Optionally specify `showbase` which will prefix
 the string with `0x` or `0X`; optionally specify `uppercase` which will set the case of the hex digits.
 

--- a/README.md
+++ b/README.md
@@ -1567,8 +1567,9 @@ Another approach to setting a custom range for an enum is to alias the first and
 using `ce_first` and `ce_last`. For example:
 ```c++
 enum class foo { one, two, three, four, five, size, seven, eight, ce_first=one, ce_last=eight };
-std::cout << conjure_enum<foo>::get_enum_min_value() << '/' << conjure_enum<foo>::get_enum_max_value() << '\n';
-std::cout << conjure_enum<foo>::get_actual_enum_min_value() << '/' << conjure_enum<foo>::get_actual_enum_max_value() << '\n';
+using fn = conjure_enum<foo>;
+std::cout << fn::get_enum_min_value() << '/' << fn::get_enum_max_value() << '\n';
+std::cout << fn::get_actual_enum_min_value() << '/' << fn::get_actual_enum_max_value() << '\n';
 ```
 _output_
 ```CSV

--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,8 @@ int main(void)
 {
    for(const auto& [a, b] : conjure_enum<component>::entries)
       std::cout << conjure_enum<component>::enum_to_int(a) << ' ' << b << '\n';
+   for(const auto& a : conjure_enum<component>::names)
+      std::cout << a << '\n';
    std::cout << static_cast<int>(conjure_enum<component>::string_to_enum("component::path").value()) << '\n';
    std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_max_value() << '\n';
    return 0;
@@ -1471,6 +1473,16 @@ $ ./statictest
 7 component::path
 8 component::query
 9 component::fragment
+component::scheme
+component::authority
+component::userinfo
+component::user
+component::password
+component::host
+component::port
+component::path
+component::query
+component::fragment
 7
 0/9
 $
@@ -1572,7 +1584,8 @@ ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ex
 The results will be printed to the screen. For example:
 <details><summary><i>output</i></summary>
 <p>
-<pre>Processing all files and saving to 'cbenchmark.dat'...
+```CSV
+Processing all files and saving to 'cbenchmark.dat'...
   done in 0.0s. Run 'ClangBuildAnalyzer --analyze cbenchmark.dat' to analyze it.
 Analyzing build trace from 'cbenchmark.dat'...
 **** Time summary:
@@ -1662,7 +1675,9 @@ Compilation (2 times):
 173 ms: /usr/include/c++/14/system_error (included 1 times, avg 173 ms), included via:
   1x: <direct include>
 
-  done in 0.0s.</pre></p></details>
+  done in 0.0s.
+```
+</pre></p></details>
 
 ---
 # 8. Compiler support

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ For the latest cutting edge changes, see the [dev branch](https://github.com/fix
 
 ## b) Embracing C++20
 
-`conjure_enum`[^1] takes full advantage of recently added C++20 features. We've leveraged the convenience of `std::source_location` and
-unlocked the potential of `constexpr` algorithms and concepts.
+`conjure_enum`[^1] takes full advantage of recently added C++20 features. We've leveraged the convenience of [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location) and
+unlocked the potential of `constexpr` algorithms (`__cpp_lib_constexpr_algorithms`) and [concepts](https://en.cppreference.com/w/cpp/language/constraints).
 
 ## c) Key Benefits
 

--- a/README.md
+++ b/README.md
@@ -885,7 +885,9 @@ false
 `enum_bitset` is a convenient way of creating bitsets based on `std::bitset`. It uses your enum (scoped or unscoped)
 for the bit positions (and names).
 > [!WARNING]
-> Your enum sequence _must_ be 0 based, continuous and the last value must be less than the count of enumerations.
+> - Your enum sequence _must_ be 0 based
+> - Continuous
+> - The last value must be less than the count of enumerations
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -906,9 +906,8 @@ for the bit positions (and names).
 > - Your enum sequence _must_ be 0 based
 > - Continuous
 > - The last value must be less than the count of enumerations
-> - This implementation is limited to 64 bits
->
 > We decided on these restrictions for both simplicity and practicality - bitsets only really make sense when represented in this manner.
+> - this implementation is limited to 64 bits
 
 > [!IMPORTANT]
 > You must include

--- a/README.md
+++ b/README.md
@@ -1835,9 +1835,9 @@ Compilation (2 times):
 We have benchmarked `conjure_enum` and `magic_enum`. The results are shown below. For `magic_enum` we created a separate repo (see [here](https://github.com/fix8mt/magic_enum_benchmark).
 We ran each benchmark 3 times, and averaged the results.
 | Compiler | `conjure_enum` | `magic_enum` | Notes |
-| :--- | :--- | :--- |
-| MSVC | 0.441 | 0.385 | using cl from command prompt
-| clang | 0.4 | 0.4 | using ClangBuildAnalyzer
+| :--- | :--- | :--- |:--- |
+| MSVC | 0.441 | 0.385 | using cl from command prompt|
+| clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
 
 Notes
 - MSVC: Windows 11 ThinkCentre 16x 13th Gen Intel i7-13700, 32Gb; MSVC 2022 / 17.11.0.

--- a/README.md
+++ b/README.md
@@ -1270,7 +1270,7 @@ than the count of bits.
 constexpr U get_bit_mask() const;
 constexpr U get_unused_bit_mask() const;
 ```
-Returns a bit mask that would mask off the _unused_ bits of the underlying integral.
+Returns a bit mask that would mask off the _unused_ bits of the underlying integral.<br>
 Returns a bit mask that would mask off the _used_ bits of the underlying integral.
 
 ---
@@ -1558,8 +1558,14 @@ master will not be considered.
 ---
 # 8. Notes
 ## a) enum limits
+Compilation times increase with the number of enums that use `conjure_enum` in any compilation unit.
+1. For a simple project with few enums, there is probably no need to set any limits;
+1. Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros;
+1. Where the enum is unscoped then use `enum_range` or one of the convenience macros;
+1. Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`, or 2.
+
 ### i. `FIX8_CONJURE_ENUM_MIN_VALUE`, `FIX8_CONJURE_ENUM_MAX_VALUE`
-These are set by default unless you override them by defining them in your application. They are the global range default for enums using `conjure_enum`.
+These are set by default unless you override them by defining them in your application. They are the global range default for all enums using `conjure_enum`.
 > [!IMPORTANT]
 > If you want to define these values they must appear _before_ you include `conjure_enum.hpp`.
 
@@ -1643,13 +1649,6 @@ _output_
 0/7
 0/7
 ```
-
-### iv. Which enum limit approach to use
-Compilation times increase with the number of enums that use `conjure_enum` in any compilation unit.
-1. For a simple project with few enums, there is probably no need to set any limits;
-1. Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros;
-1. Where the enum is unscoped then use `enum_range` or one of the convenience macros;
-1. Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`, or 2.
 
 ## b) Choosing the minimal build
 ```c++

--- a/README.md
+++ b/README.md
@@ -425,23 +425,27 @@ _output_
 4
 100 <-- invalid, error value
 ```
-## n) `contains`
+## n) `contains`, `is_valid`
 ```c++
 static constexpr bool contains(T value);
 static constexpr bool contains(std::string_view str);
 template<T e>
 static constexpr bool contains();
+template<T e>
+static constexpr bool is_valid();
 ```
 Returns `true` if the enum contains the given value or string.
 ```c++
 std::cout << std::format("{}\n", conjure_enum<component>::contains(component::path));
 std::cout << std::format("{}\n", conjure_enum<component1>::contains("nothing"));
 std::cout << std::format("{}\n", conjure_enum<component>::contains<component::path>());
+std::cout << std::format("{}\n", conjure_enum<component>::is_valid<component::path>());
 ```
 _output_
 ```CSV
 true
 false
+true
 true
 ```
 ## o) `for_each`, `for_each_n` ![](assets/notminimalred.svg)
@@ -662,15 +666,14 @@ _output_
 true
 false
 ```
-## r) `is_valid`
+## r) `is_continuous`
 ```c++
-template<T e>
-static constexpr bool is_valid();
+static constexpr bool is_continuous();
 ```
-Returns `true` if enum value is valid.
+Returns `true` if enum range is continuous (no gaps).
 ```c++
-std::cout << std::format("{}\n", conjure_enum<component>::is_valid<component::password>());
-std::cout << std::format("{}\n", conjure_enum<component1>::is_valid<static_cast<component>(16)>());
+std::cout << std::format("{}\n", conjure_enum<numbers>::is_continuous());
+std::cout << std::format("{}\n", conjure_enum<component>::is_continuous());
 ```
 _output_
 ```CSV
@@ -858,6 +861,20 @@ _output_
 ```CSV
 -128/127
 ```
+
+## C) `in_range`
+```c++
+static constexpr bool in_range(T value);
+```
+Returns `true` if the given value is within the minimum and maximum defined values for this enum type.
+```c++
+std::cout << std::format("{}\n", conjure_enum<component>::in_range(static_cast<component>(100)));
+```
+_output_
+```CSV
+false
+```
+
 ---
 # 4. API and Examples using `enum_bitset`
 `enum_bitset` is a convenient way of creating bitsets based on `std::bitset`. It uses your enum (scoped or unscoped)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
 > [!TIP]
 > Use the built-in [table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) to navigate this guide.
 > Even better in [full read view](./README.md) of this page.
+>
+> For the latest cutting edge changes, see the [dev branch](https://github.com/fix8mt/conjure_enum/tree/dev).
 
 ---
 # 2. Introduction
@@ -66,14 +68,12 @@ Based on the awesome work in [`magic_enum`](https://github.com/Neargye/magic_enu
 this library offers a streamlined and powerful way to add reflection capabilities to your C++ enums and other types. We've optimized the core functionality,
 focusing on the main features developers usually want. We've also added general purpose typename reflection for any type.
 
-For the latest cutting edge changes, see the [dev branch](https://github.com/fix8mt/conjure_enum/tree/dev).
-
 ## b) Embracing C++20
 
 `conjure_enum`[^1] takes full advantage of recently added C++20 features. We've leveraged the convenience of [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location) and
 unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0202r3.html) and [concepts](https://en.cppreference.com/w/cpp/language/constraints).
 
-## c) Key Benefits
+## c) Highlights
 
 - ***Single Header-Only***: No external dependencies, simplifying integration into your project
 - ***Modern C++20***: Entirely `constexpr` for compile-time safety, efficiency and performance; no macros

--- a/README.md
+++ b/README.md
@@ -1548,7 +1548,7 @@ static_assert(conjure_enum<range_test>::get_enum_min_value() == 0);
 static_assert(conjure_enum<range_test>::get_enum_max_value() == 7);
 ```
 #### ii.a `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
-For convenience, two macros are provided to make it easier to set custom ranges.
+For convenience, two macros are provided to make it easier to set custom ranges using `enum_range`.
 ```c++
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,min_int,max_int)...
 #define FIX8_CONJURE_ENUM_SET_RANGE(min_enum,max_enum)...
@@ -1590,9 +1590,9 @@ _output_
 
 ### iv. Which enum limit approach to use
 Compilation times increase with the number of enums that use `conjure_enum` in any compilation unit.
-1. For a simple project with few enums, there is probably no need to set any limits.
-1. Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros
-1. Where the enum is unscoped then use `enum_range` or one of the convenience macros
+1. For a simple project with few enums, there is probably no need to set any limits;
+1. Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros;
+1. Where the enum is unscoped then use `enum_range` or one of the convenience macros;
 1. Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`, or 2.
 
 ## b) Choosing the minimal build

--- a/README.md
+++ b/README.md
@@ -1840,9 +1840,9 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
-| MSVC | 0.376 | 0.343 | using cl from command prompt|
+| **MSVC** | 0.376 | 0.343 | using cl from command prompt|
 |_command_ | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
-| clang | 0.3 | 0.3 | using ClangBuildAnalyzer|
+| **clang** | 0.3 | 0.3 | using ClangBuildAnalyzer|
 |_command_|`make`; `ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`make`; `ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1263,7 +1263,7 @@ template<std::size_t N>
 class fixed_string;
 constexpr fixed_string(std::string_view sv);
 ```
-Constructs a `fixed_string` from a `std::string_view`. Note the size must be passed as a template paramater.
+Constructs a `fixed_string` from a `std::string_view`. The source string is _copied_ and a null character is added to the end. Note the size of the _source_ string must be passed as a template paramater.
 ```c++
 std::string_view sv{"The rain in Spain"};
 fixed_string<sv.size()> fs{sv};

--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ Additional methods
 > [!NOTE]
 > `rotl`, `rotl`, `countl*` and `countr*` operate on the _used_ bits of the underlying type.
 
-Take a look at the [implementation](include/fix8/conjure_enum.hpp) for more detail on the various API functions available.
+Take a look at the [implementation](include/fix8/enum_bitset.hpp) for more detail on the various API functions available.
 You can also review the unit test cases for examples of use.
 
 All accessors and mutators work with enum values or integers as with operators. They also work with multiple values, either as template parameters or

--- a/README.md
+++ b/README.md
@@ -568,8 +568,8 @@ template<std::size_t I, typename Fn, typename C, typename... Args> // specialisa
 requires (std::invocable<Fn&&, C, T, Args...> && I > 0)
 static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args);
 ```
-With a given enum, search and call user supplied invocable. Use this method where complex event handling is required, allowing you to easily declare predefined invocable actions
-for different enum values.
+With a given enum, search for and call user supplied invocable. You can use this method where complex event handling is required,
+allowing you to easily declare predefined invocable actions for different enum values.
 
 Where invocable returns a value, return this value or a user supplied "not found" value.
 Where invocable is void, call user supplied "not found" invocable.

--- a/README.md
+++ b/README.md
@@ -1832,14 +1832,15 @@ Compilation (2 times):
 
 ---
 # 9. Benchmarks
-We have benchmarked `conjure_enum` and `magic_enum`. The results are shown below. For `magic_enum` we created a separate repo (see [here](https://github.com/fix8mt/magic_enum_benchmark).
+We have benchmarked `conjure_enum` and `magic_enum`. The results are shown below. For `magic_enum` we created a separate repo (see [here](https://github.com/fix8mt/magic_enum_benchmark)).
 We ran each benchmark 3 times, and averaged the results.
-| Compiler | `conjure_enum` | `magic_enum` | Notes |
+| Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
 
 Notes
+- Both benchmarks are using [cbenchmark.sh](examples/cbenchmark.sh) and [cbenchmark.cpp](examples/cbenchmark.cpp)
 - MSVC: Windows 11 ThinkCentre 16x 13th Gen Intel i7-13700, 32Gb; MSVC 2022 / 17.11.0.
 - Clang: Ubuntu 24.04 12th Gen Intel i9-12900T, 32Gb; Clang 18.1.3
 - `magic_enum`: single header only

--- a/README.md
+++ b/README.md
@@ -1265,10 +1265,12 @@ constexpr int get_underlying_bit_size() const
 Returns the number of bits that the underlying integral contains. Will always be a power of 2 and an integral type. The number of bits may be larger
 than the count of bits.
 
-### viii. `get_unused_bit_mask`
+### viii. `get_bit_mask`,`get_unused_bit_mask`
 ```c++
+constexpr U get_bit_mask() const;
 constexpr U get_unused_bit_mask() const;
 ```
+Returns a bit mask that would mask off the _unused_ bits of the underlying integral.
 Returns a bit mask that would mask off the _used_ bits of the underlying integral.
 
 ---

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For the latest cutting edge changes, see the [dev branch](https://github.com/fix
 ## b) Embracing C++20
 
 `conjure_enum`[^1] takes full advantage of recently added C++20 features. We've leveraged the convenience of [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location) and
-unlocked the potential of `constexpr` algorithms (`__cpp_lib_constexpr_algorithms`) and [concepts](https://en.cppreference.com/w/cpp/language/constraints).
+unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0202r3.html) and [concepts](https://en.cppreference.com/w/cpp/language/constraints).
 
 ## c) Key Benefits
 

--- a/README.md
+++ b/README.md
@@ -1740,89 +1740,86 @@ Processing all files and saving to 'cbenchmark.dat'...
 Analyzing build trace from 'cbenchmark.dat'...
 **** Time summary:
 Compilation (2 times):
-  Parsing (frontend):            0.7 s
+  Parsing (frontend):            0.4 s
   Codegen & opts (backend):      0.0 s
 
 **** Files that took longest to parse (compiler frontend):
-   662 ms: build_clang/CMakeFiles/cbenchmark.dir/examples/cbenchmark.cpp.o
-
-**** Files that took longest to codegen (compiler backend):
-    18 ms: build_clang/CMakeFiles/cbenchmark.dir/examples/cbenchmark.cpp.o
+   423 ms: build_clang/CMakeFiles/cbenchmark.dir/examples/cbenchmark.cpp.o
 
 **** Templates that took longest to instantiate:
-   290 ms: FIX8::conjure_enum<std::errc> (1 times, avg 290 ms)
-   140 ms: FIX8::conjure_enum<std::errc>::_entries<0UL, 1UL, 2UL, 3UL, 4UL, 5UL... (1 times, avg 140 ms)
-    82 ms: FIX8::conjure_enum<std::errc>::_values<0UL, 1UL, 2UL, 3UL, 4UL, 5UL,... (1 times, avg 82 ms)
+   187 ms: FIX8::conjure_enum<std::errc> (1 times, avg 187 ms)
+   119 ms: FIX8::conjure_enum<std::errc>::_entries<0UL, 1UL, 2UL, 3UL, 4UL, 5UL... (1 times, avg 119 ms)
      8 ms: FIX8::conjure_enum<std::errc>::_sorted_entries (1 times, avg 8 ms)
-     7 ms: std::reverse_iterator<std::_Bit_iterator> (1 times, avg 7 ms)
      6 ms: std::sort<std::tuple<std::errc, std::basic_string_view<char>> *, boo... (1 times, avg 6 ms)
      6 ms: std::__sort<std::tuple<std::errc, std::basic_string_view<char>> *, _... (1 times, avg 6 ms)
-     6 ms: std::reverse_iterator<std::_Bit_const_iterator> (1 times, avg 6 ms)
-     5 ms: std::unordered_map<int, int> (1 times, avg 5 ms)
      5 ms: std::__introsort_loop<std::tuple<std::errc, std::basic_string_view<c... (1 times, avg 5 ms)
-     3 ms: std::array<std::tuple<std::errc, std::basic_string_view<char>>, 47> (1 times, avg 3 ms)
-     3 ms: std::_Hashtable<int, std::pair<const int, int>, std::allocator<std::... (1 times, avg 3 ms)
-     3 ms: FIX8::conjure_enum<std::errc>::enum_to_string (1 times, avg 3 ms)
-     3 ms: std::tuple<std::basic_string_view<char>, char, std::basic_string_vie... (1 times, avg 3 ms)
+     3 ms: std::array<std::tuple<std::errc, std::basic_string_view<char>>, 72> (1 times, avg 3 ms)
+     2 ms: std::tuple<std::basic_string_view<char>, char, std::basic_string_vie... (1 times, avg 2 ms)
      2 ms: std::__unguarded_partition_pivot<std::tuple<std::errc, std::basic_st... (1 times, avg 2 ms)
-     2 ms: std::tuple<std::errc, std::basic_string_view<char>> (1 times, avg 2 ms)
-     2 ms: std::tuple<std::errc, std::basic_string_view<char>>::tuple<const std... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::inappropriate_i... (1 times, avg 2 ms)
      2 ms: std::__move_median_to_first<std::tuple<std::errc, std::basic_string_... (1 times, avg 2 ms)
      2 ms: std::iter_swap<std::tuple<std::errc, std::basic_string_view<char>> *... (1 times, avg 2 ms)
      2 ms: std::__partial_sort<std::tuple<std::errc, std::basic_string_view<cha... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::too_many_files_... (1 times, avg 2 ms)
+     2 ms: std::tuple<std::errc, std::basic_string_view<char>> (1 times, avg 2 ms)
      2 ms: std::__heap_select<std::tuple<std::errc, std::basic_string_view<char... (1 times, avg 2 ms)
-     2 ms: std::tuple<std::basic_string_view<char>, char, std::basic_string_vie... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::no_such_file_or... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::operation_not_p... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::no_message_avai... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::operation_would... (1 times, avg 2 ms)
-     2 ms: FIX8::conjure_enum<std::errc>::_enum_name<std::errc::no_space_on_dev... (1 times, avg 2 ms)
      2 ms: std::__make_heap<std::tuple<std::errc, std::basic_string_view<char>>... (1 times, avg 2 ms)
+     1 ms: std::optional<unsigned long> (1 times, avg 1 ms)
+     1 ms: std::to_array<std::tuple<std::basic_string_view<char>, char, std::ba... (1 times, avg 1 ms)
+     1 ms: std::basic_string<char32_t> (1 times, avg 1 ms)
+     1 ms: std::basic_string<char8_t> (1 times, avg 1 ms)
+     1 ms: std::__adjust_heap<std::tuple<std::errc, std::basic_string_view<char... (1 times, avg 1 ms)
+     1 ms: std::basic_string<char16_t> (1 times, avg 1 ms)
+     1 ms: std::basic_string<wchar_t> (1 times, avg 1 ms)
+     1 ms: std::basic_string<char> (1 times, avg 1 ms)
+     1 ms: std::__and_<std::__is_swappable<std::errc>, std::__is_swappable<std:... (1 times, avg 1 ms)
+     1 ms: std::_Tuple_impl<0, std::basic_string_view<char>, char, std::basic_s... (1 times, avg 1 ms)
+     1 ms: std::__final_insertion_sort<std::tuple<std::errc, std::basic_string_... (1 times, avg 1 ms)
+     1 ms: std::basic_string<char32_t>::_M_construct<const char32_t *> (1 times, avg 1 ms)
+     1 ms: std::basic_string<char8_t>::_M_construct<const char8_t *> (1 times, avg 1 ms)
+     1 ms: std::basic_string<char16_t>::_M_construct<const char16_t *> (1 times, avg 1 ms)
+     1 ms: std::operator+<char, std::char_traits<char>, std::allocator<char>> (1 times, avg 1 ms)
 
 **** Template sets that took longest to instantiate:
-   290 ms: FIX8::conjure_enum<$> (1 times, avg 290 ms)
-   140 ms: FIX8::conjure_enum<$>::_entries<$> (1 times, avg 140 ms)
-    82 ms: FIX8::conjure_enum<$>::_values<$> (1 times, avg 82 ms)
-    78 ms: FIX8::conjure_enum<$>::_enum_name<$> (47 times, avg 1 ms)
-    55 ms: FIX8::conjure_enum<$>::_is_valid<$> (72 times, avg 0 ms)
-    38 ms: FIX8::conjure_enum<$>::_get_name<$> (47 times, avg 0 ms)
-    15 ms: std::tuple<$>::tuple<$> (20 times, avg 0 ms)
-    13 ms: std::reverse_iterator<$> (2 times, avg 6 ms)
+   187 ms: FIX8::conjure_enum<$> (1 times, avg 187 ms)
+   119 ms: FIX8::conjure_enum<$>::_entries<$> (1 times, avg 119 ms)
+    49 ms: FIX8::conjure_enum<$>::_get_name<$> (72 times, avg 0 ms)
+    12 ms: std::tuple<$>::tuple<$> (21 times, avg 0 ms)
      8 ms: FIX8::conjure_enum<$>::_sorted_entries (1 times, avg 8 ms)
      7 ms: std::basic_string<$> (5 times, avg 1 ms)
      6 ms: std::sort<$> (1 times, avg 6 ms)
      6 ms: std::__sort<$> (1 times, avg 6 ms)
+     5 ms: std::basic_string<$>::_M_construct<$> (5 times, avg 1 ms)
      5 ms: std::tuple<$> (2 times, avg 2 ms)
-     5 ms: std::_Hashtable<$> (2 times, avg 2 ms)
-     5 ms: std::unordered_map<$> (1 times, avg 5 ms)
      5 ms: std::__introsort_loop<$> (1 times, avg 5 ms)
      4 ms: std::array<$> (2 times, avg 2 ms)
-     4 ms: std::basic_string<$>::_M_construct<$> (4 times, avg 1 ms)
-     3 ms: FIX8::conjure_enum<$>::enum_to_string (1 times, avg 3 ms)
-     3 ms: std::__and_<$> (4 times, avg 0 ms)
      2 ms: std::__unguarded_partition_pivot<$> (1 times, avg 2 ms)
+     2 ms: std::__and_<$> (3 times, avg 0 ms)
      2 ms: std::__move_median_to_first<$> (1 times, avg 2 ms)
      2 ms: std::iter_swap<$> (1 times, avg 2 ms)
      2 ms: std::__partial_sort<$> (1 times, avg 2 ms)
-     2 ms: std::copy<$> (3 times, avg 0 ms)
      2 ms: std::__heap_select<$> (1 times, avg 2 ms)
-     2 ms: std::_Tuple_impl<$> (2 times, avg 1 ms)
      2 ms: std::__make_heap<$> (1 times, avg 2 ms)
+     1 ms: std::_Tuple_impl<$> (2 times, avg 0 ms)
      1 ms: std::optional<$> (1 times, avg 1 ms)
      1 ms: std::to_array<$> (1 times, avg 1 ms)
+     1 ms: std::__adjust_heap<$> (1 times, avg 1 ms)
+     1 ms: std::basic_string<$>::basic_string (2 times, avg 0 ms)
+     1 ms: std::__final_insertion_sort<$> (1 times, avg 1 ms)
+     1 ms: std::operator+<char, std::char_traits<char>, std::allocator<char>> (1 times, avg 1 ms)
+     1 ms: std::__insertion_sort<$> (1 times, avg 1 ms)
+     0 ms: FIX8::conjure_enum<$>::_tuple_comp_rev (1 times, avg 0 ms)
+     0 ms: std::tuple<std::errc, std::basic_string_view<char>>::operator= (1 times, avg 0 ms)
+     0 ms: __gnu_cxx::__to_xstring<$> (1 times, avg 0 ms)
 
 **** Functions that took longest to compile:
-     2 ms: test_conjure_enum(std::errc) (/home/davidd/prog/conjure_enum_tclass/examples/cbenchmark.cpp)
+     0 ms: test_conjure_enum(std::errc) (/home/davidd/prog/conjure_enum_tclass/examples/cbenchmark.cpp)
 
 **** Function sets that took longest to compile / optimize:
 
 **** Expensive headers:
-181 ms: /home/davidd/prog/conjure_enum_tclass/include/fix8/conjure_enum.hpp (included 1 times, avg 181 ms), included via:
+166 ms: /usr/include/c++/14/system_error (included 1 times, avg 166 ms), included via:
   1x: <direct include>
 
-173 ms: /usr/include/c++/14/system_error (included 1 times, avg 173 ms), included via:
+54 ms: /home/davidd/prog/conjure_enum_tclass/include/fix8/conjure_enum.hpp (included 1 times, avg 54 ms), included via:
   1x: <direct include>
 
   done in 0.0s.
@@ -1850,7 +1847,7 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 
 ## Discussion
 For MSVC, `magic_enum` compilation times a slighly better than `conjure_enum` (around %10). For clang the results are identical.
-From a compilation performance perspective, `conjure_enum` at least matches the performance of `magic_enum`.
+From a compilation performance perspective, `conjure_enum` roughly matches the performance of `magic_enum`.
 
 ---
 # 10. Compiler support

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 <a href="https://opensource.org/license/mit"><img src="assets/badgemitlic.svg"></a>
 
 # 1. Quick links
+||||
 --|--|--
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|

--- a/README.md
+++ b/README.md
@@ -1838,8 +1838,10 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
-| MSVC | 0.441 | 0.385 | using cl from command prompt|
+| MSVC | 0.441 | 0.385 | using cl from command prompt, `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
+| | | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
+||cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"||
 
 ## Notes
 - Benchmark run 10 times, best result shown

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 <a href="https://opensource.org/license/mit"><img src="assets/badgemitlic.svg"></a>
 
 # 1. Quick links
-||||
+|1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |--|--|--|
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|

--- a/README.md
+++ b/README.md
@@ -1168,12 +1168,13 @@ The string will be stored statically by the compiler, so you can use the statica
 > #include <fix8/conjure_type.hpp>
 > ```
 
+## `name`
+This static member is generated for your type. It is a `fixed_string` but has a built-in `std::string_view` operator.
 ```c++
 template<typename T>
 class conjure_type;
 static constexpr fixed_string name;
 ```
-This static member is generated for your type. It is a `fixed_string` but has a built-in `std::string_view` operator.
 
 ```c++
 class foo;

--- a/README.md
+++ b/README.md
@@ -1562,6 +1562,20 @@ FIX8_CONJURE_ENUM_SET_RANGE_INTS(numbers, 0, 7)
 FIX8_CONJURE_ENUM_SET_RANGE(numbers::first, numbers::eighth)
 ```
 
+### iv. using `T::ce_first` and `T::ce_last`
+Another approach to setting a custom range for an enum is to alias the first and last enum values in your enum definition
+using `ce_first` and `ce_last`. For example:
+```c++
+enum class foo { one, two, three, four, five, size, seven, eight, ce_first=one, ce_last=eight };
+std::cout << conjure_enum<foo>::get_enum_min_value() << '/' << conjure_enum<foo>::get_enum_max_value() << '\n';
+std::cout << conjure_enum<foo>::get_actual_enum_min_value() << '/' << conjure_enum<foo>::get_actual_enum_max_value() << '\n';
+```
+_output_
+```CSV
+0/7
+0/7
+```
+
 ## b) Choosing the minimal build
 ```c++
 #define FIX8_CONJURE_ENUM_MINIMAL

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
-> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most &ensp;$2log_2(N)+O(1)$&ensp; comparisons.
+> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most&ensp; $2log_2(N)+O(1)$ &ensp;comparisons.
 > If the array is _not_ sorted, complexity is linear.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
   - scoped and unscoped enums
   - enums with **aliases** and **gaps**
   - anonymous and named namespaced enums and types
-  - custom [enum ranges](#ii.-using-enum_range)
+  - custom [enum ranges](#ii-using-enum_range)
 - ***Easy to Use***: Class-based approach with intuitive syntax
 - ***Convenient***: `enum_bitset` provides an enhanced enum aware `std::bitset` (see 3 above)
 - ***Useful***: `conjure_type` gives you the type string of _any type!_ (see 4 above)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ enum class numbers { zero, one, two, three, four, five, six, seven, eight, nine 
 ## a) `enum_to_string`
 ```c++
 static constexpr std::string_view enum_to_string(T value, bool noscope=false);
+template<T e>
+static constexpr std::string_view enum_to_string();
 ```
 Returns a `std::string_view` or empty if not found. Optionally passing `true` will remove scope in result if present.
 `noscope` option ![](assets/notminimalred.svg).
@@ -123,6 +125,7 @@ auto name_trim { conjure_enum<component>::enum_to_string(component::path, true) 
 auto alias_name { conjure_enum<component>::enum_to_string(component::test) }; // alias
 auto noscope_name { conjure_enum<component1>::enum_to_string(path) };
 std::cout << name << '\n' << name_trim << '\n' << alias_name << '\n' << noscope_name << '\n';
+std::cout << conjure_enum<numbers>::enum_to_string<numbers::two>() << '\n';
 ```
 _output_
 ```CSV
@@ -130,6 +133,7 @@ component::path
 path
 component::path
 path
+numbers::two
 ```
 ### Aliases
 Because all methods in `conjure_enum` are defined _within_ a `class` instead of individual template functions in a `namespace`, you can reduce your

--- a/README.md
+++ b/README.md
@@ -1470,7 +1470,7 @@ cmake -DBUILD_CLANG_PROFILER=true ..
 ```
 ## b) Using in your application with cmake
 In `CMakeLists.txt` set your include path to:
-```bash
+```CMake
 include_directories([conjure_enum directory]/include)
 # e.g.
 set(cjedir /home/dd/prog/conjure_enum)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@
 --|--|--
 |1|[Implementation](include/fix8/conjure_enum.hpp)| For header implementation|
 |2|[`conjure_enum` API and Examples](#3-api-and-examples-using-conjure_enum)| General examples|
-|3|[`enum_bitset` API and Examples](#4-api-and-examples-using-enum_bitset)| enhanced enum aware `std::bitset`|
-|4|[`conjure_type` API and Examples](#5-api-and-examples-using-conjure_type)| any type string extractor|
+|3|[`enum_bitset` API and Examples](#4-api-and-examples-using-enum_bitset)| Enhanced enum aware `std::bitset`|
+|4|[`conjure_type` API and Examples](#5-api-and-examples-using-conjure_type)| Any type string extractor|
 |5|[Building](#6-building)| How to build or include|
 |6|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
 |7|[Notes](#7-notes)| Notes on the implementation, limits, etc|

--- a/README.md
+++ b/README.md
@@ -1263,10 +1263,10 @@ template<std::size_t N>
 class fixed_string;
 constexpr fixed_string(std::string_view sv);
 ```
-Constructs a `fixed_string` from a `std::string_view`. The source string is _copied_ and a null character is added to the end. Note the size of the _source_ string must be passed as a template paramater.
+Constructs a `fixed_string` from a `std::string_view`. The source string is _copied_ and a null character is added to the end. Note the size of the _source_ string must be passed as a template parameter.
 ```c++
 std::string_view sv{"The rain in Spain"};
-fixed_string<sv.size()> fs{sv};
+constexpr fixed_string<sv.size()> fs{sv};
 ```
 
 ## b) `get`

--- a/README.md
+++ b/README.md
@@ -596,7 +596,9 @@ for different enum values.
 - Where invocable is void, call user supplied "not found" invocable.
 
 The first parameter of your invocable must accept an enum value (passed by `dispatch`).
-Optionally provide any additional parameters. Works with lambdas, member functions, functions etc.
+Optionally provide any additional parameters.
+
+Works with lambdas, member functions, functions etc, compatible with `std::invoke`.
 
 There are two versions of `dispatch` - the first takes an enum value, a 'not found' value, and a `std::array` of `std::tuple` of enum and invocable.
 The second version takes an enum value, and a `std::array` of `std::tuple` of enum and invocable. The last element of the array is called if the enum is not found.

--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@
 |2|[`conjure_enum` API and Examples](#3-api-and-examples-using-conjure_enum)| General examples|
 |3|[`enum_bitset` API and Examples](#4-api-and-examples-using-enum_bitset)| Enhanced enum aware `std::bitset`|
 |4|[`conjure_type` API and Examples](#5-api-and-examples-using-conjure_type)| Any type string extractor|
-|5|[Building](#6-building)| How to build or include|
-|6|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
-|7|[Notes](#8-notes)| Notes on the implementation, limits, etc|
-|8|[Compilers](#9-compiler-support)| Supported compilers|
-|9|[Compiler issues](#10-compiler-issues)| Workarounds for various compiler issues|
-|10|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
+|5|[`fixed_string` API](#6-api-for-fixed-string)| Fixed string|
+|6|[Building](#7-building)| How to build or include|
+|7|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
+|8|[Notes](#8-notes)| Notes on the implementation, limits, etc|
+|9|[Compilers](#9-compiler-support)| Supported compilers|
+|10|[Compiler issues](#10-compiler-issues)| Workarounds for various compiler issues|
+|11|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
 > [!TIP]
 > Use the built-in [table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) to navigate this guide.
 > Even better in [full read view](./README.md) of this page.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ _output_
 ```CSV
 10
 ```
-## g) `names`
+## g) `names` ![](assets/notminimalred.svg)
 ```c++
 static constexpr std::array<std::string_view, std::size_t> names;
 ```
@@ -443,7 +443,7 @@ true
 false
 true
 ```
-## o) `for_each`, `for_each_n`
+## o) `for_each`, `for_each_n` ![](assets/notminimalred.svg)
 ```c++
 template<typename Fn, typename... Args>
 requires std::invocable<Fn&&, T, Args...>
@@ -547,7 +547,7 @@ _output_
 ```CSV
 160
 ```
-## p) `dispatch`
+## p) `dispatch` ![](assets/notminimalred.svg)
 ```c++
 template<typename Fn>
 static constexpr bool tuple_comp(const std::tuple<T, Fn>& pl, const std::tuple<T, Fn>& pr);
@@ -734,7 +734,7 @@ true
 false
 false
 ```
-## w) `iterators`
+## w) `iterators` ![](assets/notminimalred.svg)
 ```c++
 static constexpr auto cbegin();
 static constexpr auto cend();
@@ -784,7 +784,7 @@ _output_
 8
 9
 ```
-## y) `front, back`
+## y) `front, back` ![](assets/notminimalred.svg)
 ```c++
 static constexpr auto front();
 static constexpr auto back();
@@ -1423,10 +1423,14 @@ Static structures and API calls that will be excluded are:
 scoped_entries
 unscoped_entries
 rev_scoped_entries
+names
 unscoped_names
 remove_scope
 add_scope
 unscoped_string_to_enum
+for_each,for_each_n
+dispatch
+iterators
 enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
@@ -1453,8 +1457,6 @@ int main(void)
 {
    for(const auto& [a, b] : conjure_enum<component>::entries)
       std::cout << conjure_enum<component>::enum_to_int(a) << ' ' << b << '\n';
-   for(const auto& a : conjure_enum<component>::names)
-      std::cout << a << '\n';
    std::cout << static_cast<int>(conjure_enum<component>::string_to_enum("component::path").value()) << '\n';
    std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_max_value() << '\n';
    return 0;

--- a/README.md
+++ b/README.md
@@ -1433,13 +1433,13 @@ This implementation is header only. Apart from standard C++20 includes there are
 #### \*nix based environments
 To clone and default build the test app, unit tests and the benchmark:
 ```bash
-git clone https://github.com/fix8mt/conjure_enum.git
-cd conjure_enum
-mkdir build
-cd build
-cmake ..
-make -j4
-ctest (or make test)
+$ git clone https://github.com/fix8mt/conjure_enum.git
+$ cd conjure_enum
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make -j4
+$ ctest (or make test)
 ```
 #### Windows environments
 Create a new console project. Add the repo `https://github.com/fix8mt/conjure_enum.git` and clone the source.
@@ -1451,22 +1451,22 @@ The package is also available on [vckpg](https://vcpkg.io/en/package/conjure-enu
 ### ii. Default compiler warnings
 By default all warnings are enabled. To prevent this, pass the following to cmake:
 ```bash
-cmake -DBUILD_ALL_WARNINGS=false ..
+$ cmake -DBUILD_ALL_WARNINGS=false ..
 ```
 ### iii. Default unit tests
 By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
 ```bash
-cmake -DBUILD_UNITTESTS=false ..
+$ cmake -DBUILD_UNITTESTS=false ..
 ```
 ### iv. Default executable stripping
 To disable stripping of the executables:
 ```bash
-cmake -DBUILD_STRIP_EXE=false ..
+$ cmake -DBUILD_STRIP_EXE=false ..
 ```
 ### v. Clang compilation profiling
 To enable clang compilation profiling:
 ```bash
-cmake -DBUILD_CLANG_PROFILER=true ..
+$ cmake -DBUILD_CLANG_PROFILER=true ..
 ```
 ## b) Using in your application with cmake
 In `CMakeLists.txt` set your include path to:

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@
 |6|[Building](#7-building)| How to build or include|
 |7|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
 |8|[Notes](#8-notes)| Notes on the implementation, limits, etc|
-|9|[Compilers](#9-compiler-support)| Supported compilers|
-|10|[Compiler issues](#10-compiler-issues)| Workarounds for various compiler issues|
-|11|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
+|9|[Benchmarks](#9-benchmarks)| Benchmarking |
+|10|[Compilers](#10-compiler-support)| Supported compilers|
+|11|[Compiler issues](#11-compiler-issues)| Workarounds for various compiler issues|
+|12|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
 > [!TIP]
 > Use the built-in [table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) to navigate this guide.
 > Even better in [full read view](./README.md) of this page.
@@ -86,7 +87,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
 - ***Easy to Use***: Class-based approach with intuitive syntax
 - ***Convenient***: `enum_bitset` provides an enhanced enum aware `std::bitset` (see 3 above)
 - ***Useful***: `conjure_type` gives you the type string of _any type!_ (see 4 above)
-- ***Wide Compiler Compatibility***: Support for: (see 7 above)
+- ***Wide Compiler Compatibility***: Support for: (see 10 above)
   - GCC
   - Clang
   - MSVC
@@ -99,7 +100,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
   - `for_each_n`
   - `dispatch`
   - iterators and more!
-- ***Transparency***: Compiler implementation variability fully documented, verifiable and reportable (see 9 above)
+- ***Transparency***: Compiler implementation variability fully documented, verifiable and reportable (see 12 above)
 
 ---
 # 3. API and Examples using `conjure_enum`
@@ -1830,7 +1831,22 @@ Compilation (2 times):
 </p></details>
 
 ---
-# 9. Compiler support
+# 9. Benchmarks
+We have benchmarked `conjure_enum` and `magic_enum`. The results are shown below. For `magic_enum` we created a separate repo (see [here](https://github.com/fix8mt/magic_enum_benchmark).
+We ran each benchmark 3 times, and averaged the results.
+| Compiler | `conjure_enum` | `magic_enum` | Notes |
+| :--- | :--- | :--- |
+| MSVC | 0.441 | 0.385 | using cl from command prompt
+| clang | 0.4 | 0.4 | using ClangBuildAnalyzer
+
+Notes
+- MSVC: Windows 11 ThinkCentre 16x 13th Gen Intel i7-13700, 32Gb; MSVC 2022 / 17.11.0.
+- Clang: Ubuntu 24.04 12th Gen Intel i9-12900T, 32Gb; Clang 18.1.3
+- `magic_enum`: single header only
+- `conjure_enum`: minimal build
+
+---
+# 10. Compiler support
 | Compiler | Version(s) | Notes | Unsupported |
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
@@ -1838,7 +1854,7 @@ Compilation (2 times):
 | [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.0`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
-# 10. Compiler issues
+# 11. Compiler issues
 | Compiler | Version(s) | Issues | Workaround |
 | :--- | :--- | :--- | ---: |
 | clang | `16`, `17`, `18`| Compiler reports integers outside valid range [x,y]| specify underlying type when declaring enum eg. `enum class foo : int` |

--- a/README.md
+++ b/README.md
@@ -1537,19 +1537,21 @@ $
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
 ## f) Clang compile profiling
-You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer). Then configure with:
+You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
+Then configure `conjure_enum` with:
 ```CMake
 cmake -DBUILD_CLANG_PROFILER=true ..
 ```
-You can follow the instructions given on the `ClangBuildAnalyzer` page to run, alternatively after you build the included program `cbenchmark.cpp`,
+You can follow the instructions given on the `ClangBuildAnalyzer` page to run. Alternatively after you build the included program `cbenchmark`,
 run the included script [cbenchmark.sh](examples/cbenchmark.sh). The script expects the following environment variables:
 
 | Variable | Description |
 | :--- | :--- |
 | `ClangBuildAnalyzerLoc` | directory where ClangBuildAnalyzer can be found|
-| `ArtifactLoc` | directory where conjure_enum is built|
+| `ArtifactLoc` | directory where `conjure_enum` is built|
 
-For example, if `ClangBuildAnalyzer` was built in `~/prog/ClangBuildAnalyzer/build` and your `conjure_enum` build was in `./build_clang`, then:
+For example, if `ClangBuildAnalyzer` was built in `~/prog/ClangBuildAnalyzer/build` and your `conjure_enum` build was in `./build_clang`, then you
+would run the script from the `conjure_enum` directory as follows:
 ```bash
 ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh
 ```

--- a/README.md
+++ b/README.md
@@ -1272,24 +1272,25 @@ fixed_string<sv.size()> fs{sv};
 ```c++
 constexpr std::string_view get() const;
 ```
-Returns the strings as a `std::string_view`;
+Returns the string as a `std::string_view`.
 
 ## c) `c_str`
 ```c++
 constexpr const char *c_str() const;
 ```
-Returns the strings as a null terminated `const char *`.
+Returns the string as a null terminated `const char *`.
 
-## d) `c_str`
+## d) `operator std::string_view`
 ```c++
 constexpr operator std::string_view() const;
 ```
-Provides a `std::string_view` cast.
+Provides a `std::string_view` cast. Returns the string as a `std::string_view`.
 
-## e) `c_str`
+## e) `operator[]`
 ```c++
 constexpr char operator[](size_t idx) const;
 ```
+Returns the character at the specifdined index. It is not range checked.
 
 ## f) `size`
 ```c++

--- a/README.md
+++ b/README.md
@@ -195,23 +195,26 @@ _output_
 12
 100 <-- invalid, error value
 ```
-## d) `int_to_enum`
+## d) `int_to_enum`, `enum_cast`
 ```c++
 static constexpr std::optional<T> int_to_enum(int value);
+static constexpr T enum_cast(int value);
 ```
 Returns a `std::optional<T>`. Empty if value was not valid. Use `std::optional<T>::value_or()` to set an error value
-and avoid throwing an exception.
+and avoid throwing an exception. `enum_cast` will cast to the enum type regardless of whether the value is a valid enum.
 ```c++
 int value { static_cast<int>(conjure_enum<component>::int_to_enum(12).value()) };
 int noscope_value { static_cast<int>(conjure_enum<component1>::int_to_enum(12).value()) };
 int bad_value { static_cast<int>(conjure_enum<component>::int_to_enum(100).value_or(component(100))) };
 std::cout << value << '\n' << noscope_value << '\n' << bad_value << '\n';
+std::cout << static_cast<int>(conjure_enum<component>::enum_cast(150)) << '\n';
 ```
 _output_
 ```CSV
 12
 12
 100 <-- invalid, error value
+150 <-- invalid, but still casted
 ```
 ## e) `enum_to_int`, `enum_to_underlying`
 ```c++

--- a/README.md
+++ b/README.md
@@ -1568,7 +1568,7 @@ using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the 
 You can set either, both or neither. A range value not set will default to the `FIX8_CONJURE_ENUM_MIN_VALUE` or `FIX8_CONJURE_ENUM_MAX_VALUE`.
 
 > [!WARNING]
-> For unscoped enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined, due to the open scoping of unscoped
+> For unscoped enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined in any translation unit (ODR), due to the open scoping of unscoped
 > enums. It is therefore recommended to only use this feature with scoped enumns.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -589,17 +589,19 @@ template<std::size_t I, typename Fn, typename C, typename... Args> // specialisa
 requires (std::invocable<Fn&&, C, T, Args...> && I > 0)
 static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args);
 ```
-With a given enum, search and call user supplied invocable. Use this method where complex event handling is required, allowing you to easily declare predefined invocable actions
+With a given enum, search and call user supplied invocable. A typical use case would be where you want to demux a complex event, allowing you to easily declare predefined invocable actions
 for different enum values.
 
-Where invocable returns a value, return this value or a user supplied "not found" value.
-Where invocable is void, call user supplied "not found" invocable.
+- Where invocable returns a value, return this value or a user supplied "not found" value.
+- Where invocable is void, call user supplied "not found" invocable.
+
 The first parameter of your invocable must accept an enum value (passed by `dispatch`).
 Optionally provide any additional parameters. Works with lambdas, member functions, functions etc.
 
 There are two versions of `dispatch` - the first takes an enum value, a 'not found' value, and a `std::array` of `std::tuple` of enum and invocable.
 The second version takes an enum value, and a `std::array` of `std::tuple` of enum and invocable. The last element of the array is called if the enum is not found.
 This version is intended for use with `void` return invocables.
+
 The second version of each of the above is intended to be used when using a member function - the _first_ parameter passed after your array must be the `this` pointer of the object.
 You can also use `std::bind` to bind the this pointer and any parameter placeholders when declaring your array.
 If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@
 # 1. Quick links
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |:--|:--|:--|
-|1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|
 |3|[`conjure_type`](#5-conjure_type)| Any type string extractor|
 |4|[`fixed_string`](#6-fixed_string)| Statically stored null terminated fixed string|

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ _output_
 8 numbers::eight
 9 numbers::nine
 ```
-## x) `iterator_adaptor`
+## x) `iterator_adaptor` ![](assets/notminimalred.svg)
 ```c++
 template<valid_enum T>
 struct iterator_adaptor;
@@ -801,7 +801,7 @@ _output_
 0 numbers::zero
 9 numbers::nine
 ```
-## z) `ostream_enum_operator`
+## z) `ostream_enum_operator` ![](assets/notminimalred.svg)
 ```c++
 template<typename CharT, typename Traits=std::char_traits<CharT>, valid_enum T>
 constexpr std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, T value);

--- a/README.md
+++ b/README.md
@@ -1827,7 +1827,7 @@ Compilation (2 times):
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
 | [clang](https://clang.llvm.org/cxx_status.html) | `15`, `16`, `17`, `18`| Catch2 needs `cxx_std_20` in `15` | `<= 14` |
-| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.10.5`| `<= 16.9`|
+| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.0`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
 # 10. Compiler issues

--- a/README.md
+++ b/README.md
@@ -1841,9 +1841,7 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
 |_command_ | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
-|_command_|`make`
-`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`make`
-`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
+|_command_|`make`; `ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`make`; `ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 
 ## Notes
 - Benchmark run 10 times, best result shown

--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,13 @@ not found: 5
 # 5. API and Examples using `conjure_type`
 `conjure_type` is a general purpose class allowing you to extract a string representation of any typename.
 The string will be stored statically by the compiler, so you can use the statically generated value `name` to obtain your type.
+> [!IMPORTANT]
+> You must include
+```C++
+#include <fix8/conjure_enum.hpp>
+#include <fix8/conjure_type.hpp>
+```
+
 ```c++
 template<typename T>
 class conjure_type;

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ _output_
 true
 false
 ```
-## s) `type_name`
+## s) `type_name` ![](assets/notminimalred.svg)
 ```c++
 static constexpr std::string_view type_name();
 ```
@@ -1467,6 +1467,7 @@ remove_scope
 add_scope
 unscoped_string_to_enum
 for_each,for_each_n
+type_name
 dispatch
 iterators
 enum_to_string //noscope option not available
@@ -1602,7 +1603,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## f) Clang compile profiling
+## f) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ enum class numbers { zero, one, two, three, four, five, six, seven, eight, nine 
 >   requires std::same_as<T, std::decay_t<T>>;
 >   requires std::is_enum_v<T>;
 >};
-> ```
+```
 
 ## a) `enum_to_string`
 ```c++

--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 > Your `std::array` of `std::tuple` should be sorted by enum.
 > The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most&ensp; $2log_2(N)+O(1)$ &ensp;comparisons.
 > If the array is _not_ sorted, complexity is linear.
+
 The following example uses a `static constexpr` array of pointers to functions. For bevity the most point to the same function except the last which is
 a lambda.
 ```c++

--- a/README.md
+++ b/README.md
@@ -1547,7 +1547,7 @@ struct FIX8::enum_range<range_test>
 static_assert(conjure_enum<range_test>::get_enum_min_value() == 0);
 static_assert(conjure_enum<range_test>::get_enum_max_value() == 7);
 ```
-#### `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
+#### ii.1 `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
 For convenience, two macros are provided to make it easier to set custom ranges.
 ```c++
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,min_int,max_int)...

--- a/README.md
+++ b/README.md
@@ -1839,9 +1839,9 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
-| | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
+| | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`||
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
-||`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`|
+||`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 
 ## Notes
 - Benchmark run 10 times, best result shown

--- a/README.md
+++ b/README.md
@@ -915,8 +915,6 @@ for the bit positions (and names).
 > #include <fix8/conjure_enum.hpp>
 > #include <fix8/conjure_enum_bitset.hpp>
 > ```
-
-> [!IMPORTANT]
 > Your enum _must_ satisfy the following:
 > ```C++
 >template<typename T>

--- a/README.md
+++ b/README.md
@@ -1575,8 +1575,8 @@ For example:
 ```c++
 enum class range_test
 {
-	first, second, third, fourth, fifth, sixth, seventh, eighth,
-	ce_first=first, ce_last=eighth
+   first, second, third, fourth, fifth, sixth, seventh, eighth,
+   ce_first=first, ce_last=eighth
 };
 using rt = conjure_enum<range_test>;
 std::cout << rt::get_enum_min_value() << '/' << rt::get_enum_max_value() << '\n';

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Based on the awesome work in [`magic_enum`](https://github.com/Neargye/magic_enu
 this library offers a streamlined and powerful way to add reflection capabilities to your C++ enums and other types. We've optimized the core functionality,
 focusing on the main features developers usually want. We've also added general purpose typename reflection for any type.
 
+For the latest cutting edge changes, see the [dev branch](https://github.com/fix8mt/conjure_enum/tree/dev).
+
 ## b) Embracing C++20
 
 `conjure_enum`[^1] takes full advantage of recently added C++20 features. We've leveraged the convenience of `std::source_location` and

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@
 |4|[`conjure_type` API and Examples](#5-api-and-examples-using-conjure_type)| Any type string extractor|
 |5|[Building](#6-building)| How to build or include|
 |6|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
-|7|[Notes](#7-notes)| Notes on the implementation, limits, etc|
-|8|[Compilers](#8-compiler-support)| Supported compilers|
-|9|[Compiler issues](#9-compiler-issues)| Workarounds for various compiler issues|
+|7|[Notes](#8-notes)| Notes on the implementation, limits, etc|
+|8|[Compilers](#9-compiler-support)| Supported compilers|
+|9|[Compiler issues](#10-compiler-issues)| Workarounds for various compiler issues|
 |10|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
 > [!TIP]
 > Use the built-in [table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) to navigate this guide.
@@ -1252,7 +1252,59 @@ static consteval const char* FIX8::conjure_type<T>::tpeek() [with T = test]
 ```
 
 ---
-# 6. Building
+# 6. API for `fixed_string`
+`fixed_string` is a specialisation of `std::array` that provides statics storage for an ASCII zero (asciiz) string. The purpose of this class is to allow the
+creation of `constexpr` strings with specfic storage, adding a trailing `0`. It is used by `conjure_enum` to store all strings. API is described below. Other uses of this class are possible.
+
+## a) Creating a `fixed_string`
+```c++
+template<std::size_t N>
+class fixed_string;
+constexpr fixed_string(std::string_view sv);
+```
+Constructs a `fixed_string` from a `std::string_view`. Note the size must be passed as a template paramater.
+```c++
+std::string_view sv{"The rain in Spain"};
+fixed_string<sv.size()> fs{sv};
+```
+
+## b) `get`
+```c++
+constexpr std::string_view get() const;
+```
+Returns the strings as a `std::string_view`;
+
+## c) `c_str`
+```c++
+constexpr const char *c_str() const;
+```
+Returns the strings as a null terminated `const char *`.
+
+## d) `c_str`
+```c++
+constexpr operator std::string_view() const;
+```
+Provides a `std::string_view` cast.
+
+## e) `c_str`
+```c++
+constexpr char operator[](size_t idx) const;
+```
+
+## f) `size`
+```c++
+constexpr std::size_t size() const;
+```
+Returns the size of the `fixed_string` including the null terminator.
+
+## g) `std::ostream& operator<<`
+```c++
+std::ostream& operator<<(std::ostream& os, const fixed_string& what)
+```
+Provides an `ostream` insertor.
+
+---
+# 7. Building
 This implementation is header only. Apart from standard C++20 includes there are no external dependencies needed in your application.
 [Catch2](https://github.com/catchorg/Catch2.git) is used for the built-in unit tests.
 
@@ -1387,7 +1439,7 @@ Contributions are welcome. Make your changes in [your fork on the dev branch](ht
 master will not be considered.
 
 ---
-# 7. Notes
+# 8. Notes
 ## a) enum limits
 ### i. `FIX8_CONJURE_ENUM_MIN_VALUE`, `FIX8_CONJURE_ENUM_MAX_VALUE`
 These are set by default unless you override them by defining them in your application. They are the global range default for enums using `conjure_enum`.
@@ -1751,7 +1803,7 @@ Compilation (2 times):
 </p></details>
 
 ---
-# 8. Compiler support
+# 9. Compiler support
 | Compiler | Version(s) | Notes | Unsupported |
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
@@ -1759,7 +1811,7 @@ Compilation (2 times):
 | [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.10.5`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
-# 9. Compiler issues
+# 10. Compiler issues
 | Compiler | Version(s) | Issues | Workaround |
 | :--- | :--- | :--- | ---: |
 | clang | `16`, `17`, `18`| Compiler reports integers outside valid range [x,y]| specify underlying type when declaring enum eg. `enum class foo : int` |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 --|--|--
 |1|[Implementation](include/fix8/conjure_enum.hpp)| For header implementation|
 |2|[`conjure_enum`](#3-conjure_enum)| API and examples|
-|3|[`enum_bitset`](#4-using-enum_bitset)| Enhanced enum aware `std::bitset`|
+|3|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|
 |4|[`conjure_type`](#5-conjure_type)| Any type string extractor|
 |5|[`fixed_string`](#6-fixed_string)| Statically stored null terminated fixed string|
 |6|[Building](#7-building)| How to build or include|

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@
 ||**Link**|**Description**|
 --|--|--
 |1|[Implementation](include/fix8/conjure_enum.hpp)| For header implementation|
-|2|[`conjure_enum`](#3-conjure_enum)| General examples|
+|2|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |3|[`enum_bitset`](#4-using-enum_bitset)| Enhanced enum aware `std::bitset`|
 |4|[`conjure_type`](#5-conjure_type)| Any type string extractor|
-|5|[`fixed_string`](#6-fixed_string)| Statically stored fixed string|
+|5|[`fixed_string`](#6-fixed_string)| Statically stored null terminated fixed string|
 |6|[Building](#7-building)| How to build or include|
 |7|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
 |8|[Notes](#8-notes)| Notes on the implementation, limits, etc|

--- a/README.md
+++ b/README.md
@@ -1564,7 +1564,9 @@ FIX8_CONJURE_ENUM_SET_RANGE(numbers::first, numbers::eighth)
 
 ### iv. using `T::ce_first` and `T::ce_last`
 Another approach to setting a custom range for an enum is to alias the first and last enum values in your enum definition
-using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the enum range. For example:
+using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the enum range.
+You can set either, both or neither. A range value not set will default to the `FIX8_CONJURE_ENUM_MIN_VALUE` or `FIX8_CONJURE_ENUM_MAX_VALUE`.
+For example:
 ```c++
 enum class range_test { first, second, third, fourth, fifth, sixth, seventh, eighth, ce_first=first, ce_last=eighth };
 using rt = conjure_enum<range_test>;

--- a/README.md
+++ b/README.md
@@ -1978,7 +1978,7 @@ From a compilation performance perspective, `conjure_enum` roughly matches the p
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
 | [clang](https://clang.llvm.org/cxx_status.html) | `15`, `16`, `17`, `18`| Catch2 needs `cxx_std_20` in `15` | `<= 14` |
-| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.1`| `<= 16.9`|
+| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.2`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
 # 11. Compiler issues

--- a/README.md
+++ b/README.md
@@ -1838,8 +1838,8 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
-| MSVC | 0.441 | 0.385 | using cl from command prompt, `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
-| | cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll" | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
+| MSVC | 0.441 | 0.385 | using cl from command prompt|
+| | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
 ||`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`|
 

--- a/README.md
+++ b/README.md
@@ -1429,7 +1429,8 @@ This implementation is header only. Apart from standard C++20 includes there are
 [Catch2](https://github.com/catchorg/Catch2.git) is used for the built-in unit tests.
 
 ## a) Obtaining the source, building the unittests and examples
-### i. \*nix based environments
+### i. Build platofrm
+#### \*nix based environments
 To clone and default build the test app, unit tests and the benchmark:
 ```bash
 git clone https://github.com/fix8mt/conjure_enum.git
@@ -1440,31 +1441,31 @@ cmake ..
 make -j4
 ctest (or make test)
 ```
-### ii. Windows environments
+#### Windows environments
 Create a new console project. Add the repo `https://github.com/fix8mt/conjure_enum.git` and clone the source.
 Make sure you set the C++ language to C++20 in the project preferences. The project should build and run the unit tests
 by default.
 
 The package is also available on [vckpg](https://vcpkg.io/en/package/conjure-enum).
 
-### iii. Default compiler warnings
+### ii. Default compiler warnings
 By default all warnings are enabled. To prevent this, pass the following to cmake:
 ```cmake
 cmake -DBUILD_ALL_WARNINGS=false ..
 ```
-### iv. Default unit tests
+### iii. Default unit tests
 By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
 ```cmake
 cmake -DBUILD_UNITTESTS=false ..
 ```
-### v. Default executable stripping
+### iv. Default executable stripping
 To disable stripping of the executables:
 ```cmake
 cmake -DBUILD_STRIP_EXE=false ..
 ```
-### vi. Clang compilation profiling
+### v. Clang compilation profiling
 To enable clang compilation profiling:
-```CMake
+```cmake
 cmake -DBUILD_CLANG_PROFILER=true ..
 ```
 ## b) Using in your application with cmake

--- a/README.md
+++ b/README.md
@@ -1839,9 +1839,9 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
 | MSVC | 0.441 | 0.385 | using cl from command prompt, `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
-| | | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
+| | cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll" | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`|
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
-||cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"||
+||`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`|
 
 ## Notes
 - Benchmark run 10 times, best result shown

--- a/README.md
+++ b/README.md
@@ -847,19 +847,24 @@ static consteval const char* FIX8::conjure_enum<T>::tpeek() [with T = component]
 static consteval const char* FIX8::conjure_enum<T>::epeek() [with T e = component::path; T = component]
 ```
 
-## B) `get_enum_min_value` and `get_enum_max_value`
+## B) `get_enum_min_value`, `get_enum_max_value`, `get_enum_min_actual_value` and `get_enum_max_actual_value`
 ```c++
 static constexpr int get_enum_min_value();
 static constexpr int get_enum_max_value();
+static constexpr int get_enum_min_actual_value();
+static constexpr int get_enum_max_actual_value();
 ```
-These functions return the min and max enum range for the specified enum. If you have specialised `enum_range` then these values
+The first two functions return the min and max enum range for the specified enum. If you have specialised `enum_range` then these values
 will be reported (see below).
+The second two functions return the actual min and max enum values as ints for the specified enum.
 ```c++
 std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_min_value() << '\n';
+std::cout << conjure_enum<component>::get_enum_min_actual_value() << '/' << conjure_enum<component>::get_enum_min_actual_value() << '\n';
 ```
 _output_
 ```CSV
 -128/127
+0/14
 ```
 
 ## C) `in_range`

--- a/README.md
+++ b/README.md
@@ -1570,10 +1570,9 @@ would run the script from the `conjure_enum` directory as follows:
 ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh
 ```
 The results will be printed to the screen. For example:
-<details><summary><i>shell output</i></summary>
+<details><summary><i>output</i></summary>
 <p>
-<pre>
-Processing all files and saving to 'cbenchmark.dat'...
+<pre>Processing all files and saving to 'cbenchmark.dat'...
   done in 0.0s. Run 'ClangBuildAnalyzer --analyze cbenchmark.dat' to analyze it.
 Analyzing build trace from 'cbenchmark.dat'...
 **** Time summary:
@@ -1663,8 +1662,7 @@ Compilation (2 times):
 173 ms: /usr/include/c++/14/system_error (included 1 times, avg 173 ms), included via:
   1x: <direct include>
 
-  done in 0.0s.
-</pre></p></details>
+  done in 0.0s.</pre></p></details>
 
 ---
 # 8. Compiler support

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@
 ||**Link**|**Description**|
 --|--|--
 |1|[Implementation](include/fix8/conjure_enum.hpp)| For header implementation|
-|2|[`conjure_enum` API and Examples](#3-api-and-examples-using-conjure_enum)| General examples|
-|3|[`enum_bitset` API and Examples](#4-api-and-examples-using-enum_bitset)| Enhanced enum aware `std::bitset`|
-|4|[`conjure_type` API and Examples](#5-api-and-examples-using-conjure_type)| Any type string extractor|
-|5|[`fixed_string` API](#6-api-for-fixed_string)| Statically stored fixed string|
+|2|[`conjure_enum`](#3-conjure_enum)| General examples|
+|3|[`enum_bitset`](#4-using-enum_bitset)| Enhanced enum aware `std::bitset`|
+|4|[`conjure_type`](#5-conjure_type)| Any type string extractor|
+|5|[`fixed_string`](#6-fixed_string)| Statically stored fixed string|
 |6|[Building](#7-building)| How to build or include|
 |7|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
 |8|[Notes](#8-notes)| Notes on the implementation, limits, etc|
@@ -61,7 +61,7 @@
 > Even better in [full read view](./README.md) of this page.
 >
 > For the latest cutting edge changes, see the [dev branch](https://github.com/fix8mt/conjure_enum/tree/dev).
-> You can view the changes [here](https://github.com/fix8mt/conjure_enum/compare/master..dev).
+> You can view the changes (if any) [here](https://github.com/fix8mt/conjure_enum/compare/master..dev).
 
 ---
 # 2. Introduction
@@ -102,7 +102,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
 - ***Transparency***: Compiler implementation variability fully documented, verifiable and reportable (see 12 above)
 
 ---
-# 3. API and Examples using `conjure_enum`
+# 3. `conjure_enum`
 All examples refer to the following enums:
 ```c++
 enum class component { scheme, authority, userinfo, user, password, host, port, path=12, test=path, query, fragment };
@@ -899,7 +899,7 @@ false
 ```
 
 ---
-# 4. API and Examples using `enum_bitset`
+# 4. `enum_bitset`
 `enum_bitset` is a convenient way of creating bitsets based on `std::bitset`. It uses your enum (scoped or unscoped)
 for the bit positions (and names).
 > [!NOTE]
@@ -1275,7 +1275,7 @@ Returns a bit mask that would mask off the _unused_ bits of the underlying integ
 Returns a bit mask that would mask off the _used_ bits of the underlying integral.
 
 ---
-# 5. API and Examples using `conjure_type`
+# 5. `conjure_type`
 `conjure_type` is a general purpose class allowing you to extract a string representation of any typename.
 The string will be stored statically by the compiler, so you can use the statically generated value `name` to obtain your type.
 > [!IMPORTANT]
@@ -1369,7 +1369,7 @@ static consteval const char* FIX8::conjure_type<T>::tpeek() [with T = test]
 ```
 
 ---
-# 6. API for `fixed_string`
+# 6. `fixed_string`
 `fixed_string` is a specialisation of `std::array` that provides statics storage for an ASCII zero (asciiz) string. The purpose of this class is to allow the
 creation of `constexpr` strings with specfic storage, adding a trailing `0`. It is used by `conjure_enum` to store all strings. API is described below. Other uses of this class are possible.
 

--- a/README.md
+++ b/README.md
@@ -1462,7 +1462,7 @@ To disable stripping of the executables:
 ```cmake
 cmake -DBUILD_STRIP_EXE=false ..
 ```
-### vi. Default executable stripping
+### vi. Clang compilation profiling
 To enable clang compilation profiling:
 ```CMake
 cmake -DBUILD_CLANG_PROFILER=true ..

--- a/README.md
+++ b/README.md
@@ -1832,19 +1832,25 @@ Compilation (2 times):
 
 ---
 # 9. Benchmarks
-We have benchmarked `conjure_enum` and `magic_enum`. The results are shown below. For `magic_enum` we created a separate repo (see [here](https://github.com/fix8mt/magic_enum_benchmark)).
-We ran each benchmark 3 times, and averaged the results.
+We have benchmarked compilation times for `conjure_enum` and `magic_enum`.
+For `magic_enum` we created a separate repo (see [here](https://github.com/fix8mt/magic_enum_benchmark)).
+
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
 
-Notes
+## Notes
+- Benchmark run 10 times, best result shown
 - Both benchmarks are using [cbenchmark.sh](examples/cbenchmark.sh) and [cbenchmark.cpp](examples/cbenchmark.cpp)
 - MSVC: Windows 11 ThinkCentre 16x 13th Gen Intel i7-13700, 32Gb; MSVC 2022 / 17.11.0.
 - Clang: Ubuntu 24.04 12th Gen Intel i9-12900T, 32Gb; Clang 18.1.3
 - `magic_enum`: single header only
 - `conjure_enum`: minimal build
+
+## Discussion
+For MSVC, `magic_enum` compilation times a slighly better than `conjure_enum` (around %10). For clang the results are identical.
+From a compilation performance perspective, `conjure_enum` at least matches the performance of `magic_enum`.
 
 ---
 # 10. Compiler support

--- a/README.md
+++ b/README.md
@@ -1564,12 +1564,12 @@ FIX8_CONJURE_ENUM_SET_RANGE(numbers::first, numbers::eighth)
 
 ### iv. using `T::ce_first` and `T::ce_last`
 Another approach to setting a custom range for an enum is to alias the first and last enum values in your enum definition
-using `ce_first` and `ce_last`. For example:
+using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the enum range. For example:
 ```c++
-enum class foo { one, two, three, four, five, size, seven, eight, ce_first=one, ce_last=eight };
-using fn = conjure_enum<foo>;
-std::cout << fn::get_enum_min_value() << '/' << fn::get_enum_max_value() << '\n';
-std::cout << fn::get_actual_enum_min_value() << '/' << fn::get_actual_enum_max_value() << '\n';
+enum class range_test { first, second, third, fourth, fifth, sixth, seventh, eighth, ce_first=first, ce_last=eighth };
+using rt = conjure_enum<range_test>;
+std::cout << rt::get_enum_min_value() << '/' << rt::get_enum_max_value() << '\n';
+std::cout << rt::get_actual_enum_min_value() << '/' << rt::get_actual_enum_max_value() << '\n';
 ```
 _output_
 ```CSV

--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ Additional methods
 | `all_of` | test for all specified bits, templated, function, types and underlyings |
 | `none_of` | test for all specified bits set to off, templated, function, types and underlyings |
 | `not_count` | complement of count, count of off bits |
+| `has_single_bit` | if bitset is an integral power of two; otherwise false|
 
 Take a look at the [implementation](include/fix8/conjure_enum.hpp) for more detail on the various API functions available.
 You can also review the unit test cases for examples of use.

--- a/README.md
+++ b/README.md
@@ -622,6 +622,8 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 > Your `std::array` of `std::tuple` should be sorted by enum.
 > The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most&ensp; $2log_2(N)+O(1)$ &ensp;comparisons.
 > If the array is _not_ sorted, complexity is linear.
+The following example uses a `static constexpr` array of pointers to functions. For bevity the most point to the same function except the last which is
+a lambda.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };
 static constexpr auto prn([](directions ev) { std::cout << conjure_enum<directions>::enum_to_string(ev) << '\n'; });

--- a/README.md
+++ b/README.md
@@ -1066,17 +1066,20 @@ Additional methods
 | :--- | :--- |
 | `set` | set all specified bits, templated |
 | `reset` | reset all specified bits, templated |
-| `rotl` | rotate underlying left specified times|
-| `rotr` | rotate underlying right specified times|
-| `countl_zero` | counts number of consecutive underlying `0` bits, starting from the most significant bit |
-| `countl_one` | counts number of consecutive underlying `1` bits, starting from the most significant bit |
-| `countr_zero` | counts number of consecutive underlying `0` bits, starting from the least significant bit |
-| `countr_one` | counts number of consecutive underlying `1` bits, starting from the least significant bit |
+| `rotl` | rotate left specified times|
+| `rotr` | rotate right specified times|
+| `countl_zero` | counts number of consecutive `0` bits, starting from the most significant bit |
+| `countl_one` | counts number of consecutive `1` bits, starting from the most significant bit |
+| `countr_zero` | counts number of consecutive `0` bits, starting from the least significant bit |
+| `countr_one` | counts number of consecutive `1` bits, starting from the least significant bit |
 | `any_of` | test for one or more bits, templated, function, types and underlyings |
 | `all_of` | test for all specified bits, templated, function, types and underlyings |
 | `none_of` | test for all specified bits set to off, templated, function, types and underlyings |
 | `not_count` | complement of count, count of off bits |
 | `has_single_bit` | return true if bitset is an integral power of two|
+
+> [!NOTE]
+> rot[lr] and count[lr] operate on the _used_ bits of the underlying type.
 
 Take a look at the [implementation](include/fix8/conjure_enum.hpp) for more detail on the various API functions available.
 You can also review the unit test cases for examples of use.

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
-> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most  $2log_2(N)+O(1)$  comparisons.
+> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most $`2log_2(N)+O(1)`$ comparisons.
 > If the array is _not_ sorted, complexity is linear.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };

--- a/README.md
+++ b/README.md
@@ -847,19 +847,19 @@ static consteval const char* FIX8::conjure_enum<T>::tpeek() [with T = component]
 static consteval const char* FIX8::conjure_enum<T>::epeek() [with T e = component::path; T = component]
 ```
 
-## B) `get_enum_min_value`, `get_enum_max_value`, `get_enum_min_actual_value` and `get_enum_max_actual_value`
+## B) `get_enum_min_value`, `get_enum_max_value`, `get_actual_enum_min_value` and `get_actual_enum_max_value`
 ```c++
 static constexpr int get_enum_min_value();
 static constexpr int get_enum_max_value();
-static constexpr int get_enum_min_actual_value();
-static constexpr int get_enum_max_actual_value();
+static constexpr int get_actual_enum_min_value();
+static constexpr int get_actual_enum_max_value();
 ```
 The first two functions return the min and max enum range for the specified enum. If you have specialised `enum_range` then these values
 will be reported (see below).
 The second two functions return the actual min and max enum values as ints for the specified enum.
 ```c++
 std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_min_value() << '\n';
-std::cout << conjure_enum<component>::get_enum_min_actual_value() << '/' << conjure_enum<component>::get_enum_min_actual_value() << '\n';
+std::cout << conjure_enum<component>::get_actual_enum_min_value() << '/' << conjure_enum<component>::get_actual_enum_min_value() << '\n';
 ```
 _output_
 ```CSV
@@ -885,7 +885,7 @@ false
 `enum_bitset` is a convenient way of creating bitsets based on `std::bitset`. It uses your enum (scoped or unscoped)
 for the bit positions (and names).
 > [!WARNING]
-> Your enum _must_ be continuous. The last value must be less than the count of enumerations.
+> Your enum sequence _must_ be 0 based, continuous and the last value must be less than the count of enumerations.
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -1588,6 +1588,7 @@ These definitions set the minimum and maximum enum values that are supported. Yo
 > If you wish to set ranges on a per enum basis, use `enum_range` (see below).
 
 ### ii. using `enum_range`
+You can specialise this class to override the defaults and set your own range on a per enum basis.
 ```c++
 template<valid_enum T>
 struct enum_range
@@ -1598,7 +1599,6 @@ struct enum_range
 The `min` and `max` values are used to set the range of enum values for enums in `conjure_enum`. As shown above, the default values will be
 `FIX8_CONJURE_ENUM_MIN_VALUE` and `FIX8_CONJURE_ENUM_MAX_VALUE`.
 
-You can specialise this class to override the defaults and set your own range on a per enum basis:
 ```c++
 enum class range_test { first, second, third, fourth, fifth, sixth, seventh, eighth };
 template<>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@
 <a href="https://opensource.org/license/mit"><img src="assets/badgemitlic.svg"></a>
 
 # 1. Quick links
-||**Link**|**Description**|
 --|--|--
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|

--- a/README.md
+++ b/README.md
@@ -864,6 +864,12 @@ for the bit positions (and names).
 > [!WARNING]
 > Your enum _must_ be continuous. The last value must be less than the count of enumerations.
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
+> [!INFO]
+> You must include
+```C++
+#include <fix8/conjure_enum.hpp>
+#include <fix8/conjure_enum_bitset.hpp>
+```
 
 ## a) Creating an `enum_bitset`
 ```c++

--- a/README.md
+++ b/README.md
@@ -1474,43 +1474,39 @@ enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
 
-## c) Continuous enum optimization
+## c) Using `enum_flags`
 ```c++
-#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+template<valid_enum T>
+struct enum_flags final
+{
+   static constexpr bool is_continuous{}, no_anon{};
+};
 ```
-If your enum(s) are continuous (no gaps) you can enable this compiler optimization
-by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`.
-Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+### i. Continuous enum optimization
+The `is_continuous` indicates that your enum(s) are continuous (no gaps). In out testing enable this compiler optimization
+shows a reduction in overall compile times.
 
-## d) Anonymous enum optimization
-```c++
-#define FIX8_CONJURE_ENUM_NO_ANON
-```
-If your enum(s) are not within any anonymous namespaces (rarely used for this purpose), you can enable this compiler optimization
-by defining `FIX8_CONJURE_ENUM_NO_ANON` _before_ you include `conjure_enum.hpp`.
-Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+### ii. Anonymous enum optimization
+The `no_anon` indicates that your enum(s) are not within any anonymous namespaces (rarely used for this purpose). In out testing enable this compiler optimization
+shows a reduction in overall compile times.
 
-## e) Enable all optimizations
+### iii. `FIX8_CONJURE_ENUM_SET_FLAGS`
+For convenience, this macro is provided to make it easier to set custom flags.  This macro takes an enum typename followed by two `bool` values indicating
+the values of `is_continuous` and `no_anon`.
+
 ```c++
-#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
-```
-You can enable all optimizations described above by defining `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` _before_ you include `conjure_enum.hpp`.
-This is the equivalent of defining:
-```c++
-#define FIX8_CONJURE_ENUM_MINIMAL
-#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
-#define FIX8_CONJURE_ENUM_NO_ANON
+FIX8_CONJURE_ENUM_SET_FLAGS(range_test, true, true)
 ```
 
-## f) Class `conjure_enum` is not constructible
+## d) Class `conjure_enum` is not constructible
 All methods in this class are _static_. You cannot instantiate an object of this type. The same goes for `conjure_type`.
 
-## g) It's not _real_ reflection
+## e) It's not _real_ reflection
 This library provides a workaround (hack :smirk:) to current limitations of C++. There are proposals out there for future versions of the language that will provide proper reflection.
 See [Reflection TS](https://en.cppreference.com/w/cpp/experimental/reflect) and [Reflection for C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html)
 for examples of some of these.
 
-## h) Use of `std::string_view`
+## f) Use of `std::string_view`
 All of the generated static strings and generated static tables obtained by `std::source_location` use the library defined `fixed_string`. No string copying is done at runtime, resulting in
 a single static string in your application. All `conjure_enum` methods that return strings _only_ return `std::string_view`.
 To demonstrate this, lets look at the supplied test application `statictest`:
@@ -1631,7 +1627,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## i) Compilation profiling (Clang)
+## g) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake

--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ Additional methods
 > [!NOTE]
 > `rotl`, `rotl`, `countl*` and `countr*` operate on the _used_ bits of the underlying type.
 
-Take a look at the [implementation](include/fix8/enum_bitset.hpp) for more detail on the various API functions available.
+Take a look at the [implementation](include/fix8/conjure_enum_bitset.hpp) for more detail on the various API functions available.
 You can also review the unit test cases for examples of use.
 
 All accessors and mutators work with enum values or integers as with operators. They also work with multiple values, either as template parameters or

--- a/README.md
+++ b/README.md
@@ -1474,15 +1474,23 @@ enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
 
-## c) Class `conjure_enum` is not constructible
+## c) Continous enum optimization
+```c++
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+```
+If your enum(s) are continuous (no gaps) you can enable this compiler optimization
+by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`
+Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+
+## d) Class `conjure_enum` is not constructible
 All methods in this class are _static_. You cannot instantiate an object of this type. The same goes for `conjure_type`.
 
-## d) It's not _real_ reflection
+## e) It's not _real_ reflection
 This library provides a workaround (hack :smirk:) to current limitations of C++. There are proposals out there for future versions of the language that will provide proper reflection.
 See [Reflection TS](https://en.cppreference.com/w/cpp/experimental/reflect) and [Reflection for C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html)
 for examples of some of these.
 
-## e) Use of `std::string_view`
+## f) Use of `std::string_view`
 All of the generated static strings and generated static tables obtained by `std::source_location` use the library defined `fixed_string`. No string copying is done at runtime, resulting in
 a single static string in your application. All `conjure_enum` methods that return strings _only_ return `std::string_view`.
 To demonstrate this, lets look at the supplied test application `statictest`:
@@ -1603,7 +1611,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## f) Compilation profiling (Clang)
+## g) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake

--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,7 @@ Additional methods
 | `has_single_bit` | return true if bitset is an integral power of two|
 
 > [!NOTE]
-> rot[lr] and count[lr] operate on the _used_ bits of the underlying type.
+> `rotl`, `rotl`, `countl*` and `countr*` operate on the _used_ bits of the underlying type.
 
 Take a look at the [implementation](include/fix8/conjure_enum.hpp) for more detail on the various API functions available.
 You can also review the unit test cases for examples of use.

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
-> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most $` 2log_2(N)+O(1) `$ comparisons.
+> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most &emsp;$2log_2(N)+O(1)$&emsp; comparisons.
 > If the array is _not_ sorted, complexity is linear.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };

--- a/README.md
+++ b/README.md
@@ -1841,7 +1841,9 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
 |_command_ | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
-|_command_|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
+|_command_|`make`
+`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`make`
+`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 
 ## Notes
 - Benchmark run 10 times, best result shown

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
-> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most &emsp;$2log_2(N)+O(1)$&emsp; comparisons.
+> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most &ensp;$2log_2(N)+O(1)$&ensp; comparisons.
 > If the array is _not_ sorted, complexity is linear.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };

--- a/README.md
+++ b/README.md
@@ -1482,12 +1482,13 @@ struct enum_flags final
    static constexpr bool is_continuous{}, no_anon{};
 };
 ```
+You can specialise this class to override the defaults and set your own flags on a per enum basis:
 ### i. Continuous enum optimization
-The `is_continuous` indicates that your enum(s) are continuous (no gaps). In out testing enable this compiler optimization
+The `is_continuous` flag indicates that your enum(s) are continuous (no gaps). In out testing enabling this compiler optimization
 shows a reduction in overall compile times.
 
 ### ii. Anonymous enum optimization
-The `no_anon` indicates that your enum(s) are not within any anonymous namespaces (rarely used for this purpose). In out testing enable this compiler optimization
+The `no_anon` indicates flag that your enum(s) are not within any anonymous namespaces (rarely used for this purpose). In out testing enabling this compiler optimization
 shows a reduction in overall compile times.
 
 ### iii. `FIX8_CONJURE_ENUM_SET_FLAGS`

--- a/README.md
+++ b/README.md
@@ -70,12 +70,10 @@ Based on the awesome work in [`magic_enum`](https://github.com/Neargye/magic_enu
 this library offers a streamlined and powerful way to add reflection capabilities to your C++ enums and other types. We've optimized the core functionality,
 focusing on the main features developers usually want. We've also added general purpose typename reflection for any type.
 
-## b) Embracing C++20
-
 `conjure_enum`[^1] takes full advantage of recently added C++20 features. We've leveraged the convenience of [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location) and
 unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0202r3.html) and [concepts](https://en.cppreference.com/w/cpp/language/constraints).
 
-## c) Highlights
+## b) Highlights
 
 - ***Single Header-Only***: No external dependencies, simplifying integration into your project
 - ***Modern C++20***: Entirely `constexpr` for compile-time safety, efficiency and performance; no macros
@@ -92,7 +90,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
   - Clang
   - MSVC
   - XCode/Apple Clang
-- ***Confidence in Quality***: Includes comprehensive unit test suite for reliable functionality and profiling
+- ***Confidence***: Includes comprehensive unit test suite for reliable functionality and profiling
 - ***Expanded***: Enhanced API:
   - `add_scope`
   - `remove_scope`

--- a/README.md
+++ b/README.md
@@ -1451,7 +1451,7 @@ Provides an `ostream` insertor.
 # 7. Building
 This implementation is header only. Apart from standard C++20 includes there are no external dependencies needed in your application.
 [Catch2](https://github.com/catchorg/Catch2.git) is used for the built-in unit tests.
-> [!NOTE]
+> [!TIP]
 > The unit test source files [unittests.cpp](utests/unittests.cpp) and [edgetests.cpp](utests/edgetests.cpp) contain additional examples for all
 > the APIs.
 

--- a/README.md
+++ b/README.md
@@ -1569,11 +1569,15 @@ You can set either, both or neither. A range value not set will default to the `
 
 > [!WARNING]
 > For unscoped enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined in any translation unit (ODR), due to the open scoping of unscoped
-> enums. It is therefore recommended to only use this feature with scoped enumns.
+> enums. It is therefore recommended to only use this feature with scoped enums.
 
 For example:
 ```c++
-enum class range_test { first, second, third, fourth, fifth, sixth, seventh, eighth, ce_first=first, ce_last=eighth };
+enum class range_test
+{
+	first, second, third, fourth, fifth, sixth, seventh, eighth,
+	ce_first=first, ce_last=eighth
+};
 using rt = conjure_enum<range_test>;
 std::cout << rt::get_enum_min_value() << '/' << rt::get_enum_max_value() << '\n';
 std::cout << rt::get_actual_enum_min_value() << '/' << rt::get_actual_enum_max_value() << '\n';

--- a/README.md
+++ b/README.md
@@ -890,13 +890,13 @@ false
 # 4. API and Examples using `enum_bitset`
 `enum_bitset` is a convenient way of creating bitsets based on `std::bitset`. It uses your enum (scoped or unscoped)
 for the bit positions (and names).
-> [!WARNING]
+> [!NOTE]
 > - Your enum sequence _must_ be 0 based
 > - Continuous
 > - The last value must be less than the count of enumerations
 > - This implementation is limited to 64 bits
 >
-> We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
+> We decided on these restrictions for both simplicity and practicality - bitsets only really make sense when represented in this manner.
 
 > [!IMPORTANT]
 > You must include

--- a/README.md
+++ b/README.md
@@ -568,8 +568,8 @@ template<std::size_t I, typename Fn, typename C, typename... Args> // specialisa
 requires (std::invocable<Fn&&, C, T, Args...> && I > 0)
 static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args);
 ```
-With a given enum, search for and call user supplied invocable. You can use this method where complex event handling is required,
-allowing you to easily declare predefined invocable actions for different enum values.
+With a given enum, search and call user supplied invocable. Use this method where complex event handling is required, allowing you to easily declare predefined invocable actions
+for different enum values.
 
 Where invocable returns a value, return this value or a user supplied "not found" value.
 Where invocable is void, call user supplied "not found" invocable.
@@ -1474,40 +1474,43 @@ enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
 
-## c) Using `enum_flags`
+## c) Continuous enum optimization
 ```c++
-template<valid_enum T>
-struct enum_flags
-{
-   static constexpr bool is_continuous{}, no_anon{};
-};
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
 ```
-You can specialise this class to override the defaults and set your own flags on a per enum basis:
-### i. Continuous enum optimization
-The `is_continuous` flag indicates that your enum(s) are continuous (no gaps). In our testing enabling this compiler optimization
-shows a reduction in overall compile times.
+If your enum(s) are continuous (no gaps) you can enable this compiler optimization
+by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`.
+Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
 
-### ii. Anonymous enum optimization
-The `no_anon` indicates flag that your enum(s) are not within any anonymous namespaces (rarely used for this purpose). In our testing enabling this compiler optimization
-shows a reduction in overall compile times.
-
-### iii. `FIX8_CONJURE_ENUM_SET_FLAGS`
-For convenience, this macro is provided to make it easier to set custom flags. This macro takes an enum typename followed by two `bool` values indicating
-the values of `is_continuous` and `no_anon`.
-
+## d) Anonymous enum optimization
 ```c++
-FIX8_CONJURE_ENUM_SET_FLAGS(range_test, true, true)
+#define FIX8_CONJURE_ENUM_NO_ANON
+```
+If your enum(s) are not within any anonymous namespaces (rarely used for this purpose), you can enable this compiler optimization
+by defining `FIX8_CONJURE_ENUM_NO_ANON` _before_ you include `conjure_enum.hpp`.
+Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+
+## e) Enable all optimizations
+```c++
+#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+```
+You can enable all optimizations described above by defining `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` _before_ you include `conjure_enum.hpp`.
+This is the equivalent of defining:
+```c++
+#define FIX8_CONJURE_ENUM_MINIMAL
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#define FIX8_CONJURE_ENUM_NO_ANON
 ```
 
-## d) Class `conjure_enum` is not constructible
+## f) Class `conjure_enum` is not constructible
 All methods in this class are _static_. You cannot instantiate an object of this type. The same goes for `conjure_type`.
 
-## e) It's not _real_ reflection
+## g) It's not _real_ reflection
 This library provides a workaround (hack :smirk:) to current limitations of C++. There are proposals out there for future versions of the language that will provide proper reflection.
 See [Reflection TS](https://en.cppreference.com/w/cpp/experimental/reflect) and [Reflection for C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html)
 for examples of some of these.
 
-## f) Use of `std::string_view`
+## h) Use of `std::string_view`
 All of the generated static strings and generated static tables obtained by `std::source_location` use the library defined `fixed_string`. No string copying is done at runtime, resulting in
 a single static string in your application. All `conjure_enum` methods that return strings _only_ return `std::string_view`.
 To demonstrate this, lets look at the supplied test application `statictest`:
@@ -1628,7 +1631,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## g) Compilation profiling (Clang)
+## i) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake
@@ -1753,7 +1756,7 @@ Compilation (2 times):
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
 | [clang](https://clang.llvm.org/cxx_status.html) | `15`, `16`, `17`, `18`| Catch2 needs `cxx_std_20` in `15` | `<= 14` |
-| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.0`| `<= 16.9`|
+| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.10.5`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
 # 9. Compiler issues

--- a/README.md
+++ b/README.md
@@ -1432,7 +1432,7 @@ This implementation is header only. Apart from standard C++20 includes there are
 ### i. Build platform
 #### \*nix based environments
 To clone and default build the test app, unit tests and the benchmark:
-```Shell
+```bash
 git clone https://github.com/fix8mt/conjure_enum.git
 cd conjure_enum
 mkdir build
@@ -1450,27 +1450,27 @@ The package is also available on [vckpg](https://vcpkg.io/en/package/conjure-enu
 
 ### ii. Default compiler warnings
 By default all warnings are enabled. To prevent this, pass the following to cmake:
-```Shell
+```bash
 cmake -DBUILD_ALL_WARNINGS=false ..
 ```
 ### iii. Default unit tests
 By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
-```Shell
+```bash
 cmake -DBUILD_UNITTESTS=false ..
 ```
 ### iv. Default executable stripping
 To disable stripping of the executables:
-```Shell
+```bash
 cmake -DBUILD_STRIP_EXE=false ..
 ```
 ### v. Clang compilation profiling
 To enable clang compilation profiling:
-```Shell
+```bash
 cmake -DBUILD_CLANG_PROFILER=true ..
 ```
 ## b) Using in your application with cmake
 In `CMakeLists.txt` set your include path to:
-```Shell
+```bash
 include_directories([conjure_enum directory]/include)
 # e.g.
 set(cjedir /home/dd/prog/conjure_enum)
@@ -1488,7 +1488,7 @@ using namespace FIX8;
 ## c) Integrating `conjure_enum` in your project with cmake FetchContent
 You can use cmake [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) to integrate `conjure_enum` with your project.
 If your project was called `myproj` with the sourcefile `myproj.cpp` then...
-```cmake
+```CMake
 project(myproj)
 add_executable (myproj myproj.cpp)
 set_target_properties(myproj PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED true)

--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,23 @@ Return the name as a `std::string_view`.
 static constexpr std::string_view as_string_view();
 ```
 
+## c) `tpeek`
+```c++
+static consteval const char *tpeek();
+```
+
+These functions return `std::source_location::current().function_name()` as `const char*` strings for type.
+The actual output is implementation dependent. See [Results of `source_location`](reference/source_location.md) for implementation specific `std::source_location` results.
+
+The following code:
+```c++
+std::cout << conjure_type<test>::tpeek() << '\n';
+```
+Generates this output with gcc:
+```CSV
+static consteval const char* FIX8::conjure_type<T>::tpeek() [with T = test]
+```
+
 ---
 # 6. Building
 This implementation is header only. Apart from standard C++20 includes there are no external dependencies needed in your application.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ enum class numbers { zero, one, two, three, four, five, six, seven, eight, nine 
 ```
 
 > [!IMPORTANT]
-> Your type _must_ be an enum, satisfying
+> Your type _must_ be an enum, satisfying:
 > ```C++
 >template<typename T>
 >concept valid_enum = requires(T)
@@ -915,6 +915,19 @@ for the bit positions (and names).
 > #include <fix8/conjure_enum.hpp>
 > #include <fix8/conjure_enum_bitset.hpp>
 > ```
+
+> [!IMPORTANT]
+> Your enum _must_ satisfy the following:
+> ```C++
+>template<typename T>
+>concept valid_bitset_enum = valid_enum<T> and requires(T)
+>{
+>   requires conjure_enum<T>::is_continuous();
+>   requires conjure_enum<T>::get_actual_enum_min_value() == 0;
+>   requires conjure_enum<T>::get_actual_enum_max_value() < conjure_enum<T>::count();
+>   requires std::bit_ceil(static_cast<unsigned>(conjure_enum<T>::get_actual_enum_max_value())) >= conjure_enum<T>::count();
+>};
+```
 
 ## a) Creating an `enum_bitset`
 ```c++

--- a/README.md
+++ b/README.md
@@ -1990,7 +1990,7 @@ From a compilation performance perspective, `conjure_enum` roughly matches the p
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
 | [clang](https://clang.llvm.org/cxx_status.html) | `15`, `16`, `17`, `18`| Catch2 needs `cxx_std_20` in `15` | `<= 14` |
 | [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.2`| `<= 16.9`|
-| [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
+| [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple Xcode Clang 15.0.0 (LLVM 16), some issues with `constexpr`, workarounds| `<= 14`|
 
 # 11. Compiler issues
 | Compiler | Version(s) | Issues | Workaround |

--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,7 @@ Additional methods
 | `all_of` | test for all specified bits, templated, function, types and underlyings |
 | `none_of` | test for all specified bits set to off, templated, function, types and underlyings |
 | `not_count` | complement of count, count of off bits |
-| `has_single_bit` | if bitset is an integral power of two; otherwise false|
+| `has_single_bit` | return true if bitset is an integral power of two|
 
 Take a look at the [implementation](include/fix8/conjure_enum.hpp) for more detail on the various API functions available.
 You can also review the unit test cases for examples of use.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
   - scoped and unscoped enums
   - enums with **aliases** and **gaps**
   - anonymous and named namespaced enums and types
-  - custom enum ranges
+  - custom [enum ranges](#ii.-using-enum_range)
 - ***Easy to Use***: Class-based approach with intuitive syntax
 - ***Convenient***: `enum_bitset` provides an enhanced enum aware `std::bitset` (see 3 above)
 - ***Useful***: `conjure_type` gives you the type string of _any type!_ (see 4 above)

--- a/README.md
+++ b/README.md
@@ -1839,9 +1839,9 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
-| | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
+|_command_ | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
-||`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
+|_command_|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 
 ## Notes
 - Benchmark run 10 times, best result shown

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ numbers::two
 Because all methods in `conjure_enum` are defined _within_ a `class` instead of individual template functions in a `namespace`, you can reduce your
 typing with standard aliases:
 ```c++
-using ec = conjure_enum<component>;
+using ec = FIX8::conjure_enum<component>;
 std::cout << std::format("\"{}\"\n", ec::enum_to_string(component::authority));
 std::cout << std::format("\"{}\"\n", ec::enum_to_string(static_cast<component>(100)));
 ```
@@ -483,13 +483,20 @@ requires std::invocable<Fn&&, C, T, Args...>
 [[maybe_unused]] static constexpr auto for_each_n(int n, Fn&& func, C *obj, Args&&... args);
 ```
 Call supplied invocable for _each_ enum value. Similar to `std::for_each` except the first parameter of your invocable must accept an enum value (passed by `for_each`).
-Optionally provide any additional parameters. Works with lambdas, member functions, functions etc. You can limit the number of calls to your
-invocable by using the `for_each_n` version with the first parameter being the maximum number to call. The second version of `for_each` and `for_each_n` is intended to be used
+Optionally provide any additional parameters. You can limit the number of calls to your invocable by using the `for_each_n` version with the first parameter
+being the maximum number to call. The second version of `for_each` and `for_each_n` is intended to be used
 when using a member function - the _second_ parameter passed by your call must be the `this` pointer of the object.
 If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 
-Returns `std::bind(std::forward<Fn>(func), std::placeholders::_1, std::forward<Args>(args)...)`
-or `std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...)` which can be stored or immediately invoked.
+Works with lambdas, member functions, functions etc, compatible with `std::invoke`.
+
+Returns
+```c++
+std::bind(std::forward<Fn>(func), std::placeholders::_1, std::forward<Args>(args)...)
+// or
+std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...)
+```
+which can be stored or immediately invoked.
 
 See `enum_bitset::for_each` to iterate through a bitset.
 ```c++

--- a/README.md
+++ b/README.md
@@ -1429,7 +1429,7 @@ This implementation is header only. Apart from standard C++20 includes there are
 [Catch2](https://github.com/catchorg/Catch2.git) is used for the built-in unit tests.
 
 ## a) Obtaining the source, building the unittests and examples
-### \*nix based environments
+### i. \*nix based environments
 To clone and default build the test app, unit tests and the benchmark:
 ```bash
 git clone https://github.com/fix8mt/conjure_enum.git
@@ -1440,24 +1440,24 @@ cmake ..
 make -j4
 ctest (or make test)
 ```
-### Windows environments
+### ii. Windows environments
 Create a new console project. Add the repo `https://github.com/fix8mt/conjure_enum.git` and clone the source.
 Make sure you set the C++ language to C++20 in the project preferences. The project should build and run the unit tests
 by default.
 
 The package is also available on [vckpg](https://vcpkg.io/en/package/conjure-enum).
 
-### Default compiler warnings
+### iii. Default compiler warnings
 By default all warnings are enabled. To prevent this, pass the following to cmake:
 ```cmake
 cmake -DBUILD_ALL_WARNINGS=false ..
 ```
-### Default unit tests
+### iv. Default unit tests
 By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
 ```cmake
 cmake -DBUILD_UNITTESTS=false ..
 ```
-### Default executable stripping
+### v. Default executable stripping
 To disable stripping of the executables:
 ```cmake
 cmake -DBUILD_STRIP_EXE=false ..

--- a/README.md
+++ b/README.md
@@ -1474,40 +1474,43 @@ enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
 
-## c) Using `enum_flags`
+## c) Continuous enum optimization
 ```c++
-template<valid_enum T>
-struct enum_flags
-{
-   static constexpr bool is_continuous{}, no_anon{};
-};
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
 ```
-You can specialise this class to override the defaults and set your own flags on a per enum basis:
-### i. Continuous enum optimization
-The `is_continuous` flag indicates that your enum(s) are continuous (no gaps). In out testing enabling this compiler optimization
-shows a reduction in overall compile times.
+If your enum(s) are continuous (no gaps) you can enable this compiler optimization
+by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`.
+Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
 
-### ii. Anonymous enum optimization
-The `no_anon` indicates flag that your enum(s) are not within any anonymous namespaces (rarely used for this purpose). In out testing enabling this compiler optimization
-shows a reduction in overall compile times.
-
-### iii. `FIX8_CONJURE_ENUM_SET_FLAGS`
-For convenience, this macro is provided to make it easier to set custom flags.  This macro takes an enum typename followed by two `bool` values indicating
-the values of `is_continuous` and `no_anon`.
-
+## d) Anonymous enum optimization
 ```c++
-FIX8_CONJURE_ENUM_SET_FLAGS(range_test, true, true)
+#define FIX8_CONJURE_ENUM_NO_ANON
+```
+If your enum(s) are not within any anonymous namespaces (rarely used for this purpose), you can enable this compiler optimization
+by defining `FIX8_CONJURE_ENUM_NO_ANON` _before_ you include `conjure_enum.hpp`.
+Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+
+## e) Enable all optimizations
+```c++
+#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+```
+You can enable all optimizations described above by defining `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` _before_ you include `conjure_enum.hpp`.
+This is the equivalent of defining:
+```c++
+#define FIX8_CONJURE_ENUM_MINIMAL
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#define FIX8_CONJURE_ENUM_NO_ANON
 ```
 
-## d) Class `conjure_enum` is not constructible
+## f) Class `conjure_enum` is not constructible
 All methods in this class are _static_. You cannot instantiate an object of this type. The same goes for `conjure_type`.
 
-## e) It's not _real_ reflection
+## g) It's not _real_ reflection
 This library provides a workaround (hack :smirk:) to current limitations of C++. There are proposals out there for future versions of the language that will provide proper reflection.
 See [Reflection TS](https://en.cppreference.com/w/cpp/experimental/reflect) and [Reflection for C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html)
 for examples of some of these.
 
-## f) Use of `std::string_view`
+## h) Use of `std::string_view`
 All of the generated static strings and generated static tables obtained by `std::source_location` use the library defined `fixed_string`. No string copying is done at runtime, resulting in
 a single static string in your application. All `conjure_enum` methods that return strings _only_ return `std::string_view`.
 To demonstrate this, lets look at the supplied test application `statictest`:
@@ -1628,7 +1631,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## g) Compilation profiling (Clang)
+## i) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake

--- a/README.md
+++ b/README.md
@@ -1168,7 +1168,7 @@ The string will be stored statically by the compiler, so you can use the statica
 > #include <fix8/conjure_type.hpp>
 > ```
 
-## `name`
+## a) `name`
 This static member is generated for your type. It is a `fixed_string` but has a built-in `std::string_view` operator.
 ```c++
 template<typename T>
@@ -1226,6 +1226,12 @@ std::cout << conjure_type<decltype(fstrv)>::name << '\n';
 _output_
 ```CSV
 std::basic_string_view<char>
+```
+
+## b) `as_string_view`
+Return the name as a `std::string_view`.
+```c++
+static constexpr std::string_view as_string_view();
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ constexpr std::string to_string(char zero='0', char one='1') const;
 
 template<bool showbase=true, bool uppercase=false>
 constexpr std::string to_hex_string() const;
+constexpr std::string to_hex_string() const;
 ```
 Inserts default string representation into `std::ostream`.<br>
 Returns a `std::string` representation of the bitset. Optionally specify which characters to use for `0` and `1`.<br>

--- a/README.md
+++ b/README.md
@@ -1474,12 +1474,12 @@ enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
 
-## c) Continous enum optimization
+## c) Continuous enum optimization
 ```c++
 #define FIX8_CONJURE_ENUM_IS_CONTINUOUS
 ```
 If your enum(s) are continuous (no gaps) you can enable this compiler optimization
-by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`
+by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`.
 Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
 
 ## d) Class `conjure_enum` is not constructible

--- a/README.md
+++ b/README.md
@@ -1137,23 +1137,30 @@ _output_
 0001001010
 ```
 
-### iii. `std::ostream& operator<<`, `to_string`
+### iii. `std::ostream& operator<<`, `to_string`, `to_hex_string`
 ```c++
 friend constexpr std::ostream& operator<<(std::ostream& os, const enum_bitset& what);
 constexpr std::string to_string(char zero='0', char one='1') const;
+
+template<bool showbase=true, bool uppercase=false>
+constexpr std::string to_hex_string() const;
 ```
 Inserts default string representation into `std::ostream`.<br>
 Returns a `std::string` representation of the bitset. Optionally specify which characters to use for `0` and `1`.
+Returns a `std::string` representation of the bitset in hex format. Optionally specify `showbase` which will prefix
+the string with `0x` or `0X`; optionally specify `uppercase` which will set the case of the hex digits.
 
 ```c++
 enum_bitset<numbers> ec(numbers::one,numbers::three,numbers::six);
 std::cout << ec << '\n';
 std::cout << ec.to_string('-', '+') << '\n';
+std::cout << ec.to_hex_string<true, true>() << '\n';
 ```
 _output_
 ```CSV
 0001001010
 ---+--+-+-
+0X4A
 ```
 ### iv. `for_each`, `for_each_n`
 ```c++

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
   - anonymous and named namespaced enums and types
   - custom [enum ranges](#ii-using-enum_range)
 - ***Easy to Use***: Class-based approach with intuitive syntax
-- ***Convenient***: `enum_bitset` provides an enhanced enum aware `std::bitset` (see 3 above)
-- ***Useful***: `conjure_type` gives you the type string of _any type!_ (see 4 above)
-- ***Wide Compiler Compatibility***: Support for: (see 10 above)
+- ***Convenient***: `enum_bitset` provides an enhanced enum aware `std::bitset` (see 2 above)
+- ***Useful***: `conjure_type` gives you the type string of _any type!_ (see 3 above)
+- ***Wide Compiler Compatibility***: Support for: (see 9 above)
   - GCC
   - Clang
   - MSVC
@@ -97,7 +97,7 @@ unlocked the potential of [`constexpr` algorithms](https://www.open-std.org/jtc1
   - `for_each_n`
   - `dispatch`
   - iterators and more!
-- ***Transparency***: Compiler implementation variability fully documented, verifiable and reportable (see 12 above)
+- ***Transparency***: Compiler implementation variability fully documented, verifiable and reportable (see 11 above)
 
 ---
 # 3. `conjure_enum`
@@ -1440,18 +1440,6 @@ cmake ..
 make -j4
 ctest (or make test)
 ```
-By default all warnings are enabled. To prevent this, pass the following to cmake:
-```cmake
-cmake -DBUILD_ALL_WARNINGS=false ..
-```
-By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
-```cmake
-cmake -DBUILD_UNITTESTS=false ..
-```
-To disable stripping of the executables:
-```cmake
-cmake -DBUILD_STRIP_EXE=false ..
-```
 ### Windows environments
 Create a new console project. Add the repo `https://github.com/fix8mt/conjure_enum.git` and clone the source.
 Make sure you set the C++ language to C++20 in the project preferences. The project should build and run the unit tests
@@ -1459,6 +1447,21 @@ by default.
 
 The package is also available on [vckpg](https://vcpkg.io/en/package/conjure-enum).
 
+### Default compiler warnings
+By default all warnings are enabled. To prevent this, pass the following to cmake:
+```cmake
+cmake -DBUILD_ALL_WARNINGS=false ..
+```
+### Default unit tests
+By default the unit tests are built (which will download Catch2). To prevent this, pass the following to cmake:
+```cmake
+cmake -DBUILD_UNITTESTS=false ..
+```
+### Default executable stripping
+To disable stripping of the executables:
+```cmake
+cmake -DBUILD_STRIP_EXE=false ..
+```
 ## b) Using in your application with cmake
 In `CMakeLists.txt` set your include path to:
 ```cmake

--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,13 @@ constexpr U get_unused_bit_mask() const;
 Returns a bit mask that would mask off the _unused_ bits of the underlying integral.<br>
 Returns a bit mask that would mask off the _used_ bits of the underlying integral.
 
+### ix. `std::hash<FIX8::enum_bitset<T>`
+```c++
+template<typename T>
+struct std::hash<FIX8::enum_bitset<T>>;
+```
+Provides a specialization of `std::hash` for `enum_bitset<T>`.
+
 ---
 # 5. `conjure_type`
 `conjure_type` is a general purpose class allowing you to extract a string representation of any typename.

--- a/README.md
+++ b/README.md
@@ -1288,7 +1288,7 @@ constexpr U get_unused_bit_mask() const;
 Returns a bit mask that would mask off the _unused_ bits of the underlying integral.<br>
 Returns a bit mask that would mask off the _used_ bits of the underlying integral.
 
-### ix. `std::hash<FIX8::enum_bitset<T>`
+### ix. `std::hash<enum_bitset<T>>`
 ```c++
 template<typename T>
 struct std::hash<FIX8::enum_bitset<T>>;

--- a/README.md
+++ b/README.md
@@ -492,9 +492,9 @@ Works with lambdas, member functions, functions etc, compatible with `std::invok
 
 Returns
 ```c++
-std::bind(std::forward<Fn>(func), std::placeholders::_1, std::forward<Args>(args)...)
+std::bind(std::forward<Fn>(func), std::placeholders::_1, std::forward<Args>(args)...);
 // or
-std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...)
+std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...);
 ```
 which can be stored or immediately invoked.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 # 1. Quick links
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
-|--|--|--|
+|:--|:--|:--|
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|
 |3|[`conjure_type`](#5-conjure_type)| Any type string extractor|

--- a/README.md
+++ b/README.md
@@ -645,6 +645,23 @@ directions::right
 not found: directions::forward
 -1
 ```
+This example uses lambdas:
+```c++
+const auto dd1
+{
+   std::to_array<std::tuple<component, std::function<int(component, int)>>>
+   ({
+      { component::scheme, [](component ev, int a) { return a * 100 + conjure_enum<component>::enum_to_int(ev); } },
+      { component::port, [](component ev, int a) { return a * 200 + conjure_enum<component>::enum_to_int(ev); } },
+      { component::fragment, [](component ev, int a) { return a * 300 + conjure_enum<component>::enum_to_int(ev); } },
+   })
+};
+std::cout << conjure_enum<component>::dispatch(component::port, -1, dd1, 10) << '\n';
+```
+_output_
+```CSV
+2006
+```
 This example uses member functions:
 ```c++
 struct foo

--- a/README.md
+++ b/README.md
@@ -1817,7 +1817,7 @@ Compilation (2 times):
      0 ms: __gnu_cxx::__to_xstring<$> (1 times, avg 0 ms)
 
 **** Functions that took longest to compile:
-     0 ms: test_conjure_enum(std::errc) (/home/davidd/prog/conjure_enum_tclass/examples/cbenchmark.cpp)
+     0 3s: test_conjure_enum(std::errc) (/home/davidd/prog/conjure_enum_tclass/examples/cbenchmark.cpp)
 
 **** Function sets that took longest to compile / optimize:
 
@@ -1840,9 +1840,9 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
-| MSVC | 0.441 | 0.385 | using cl from command prompt|
+| MSVC | 0.376 | 0.343 | using cl from command prompt|
 |_command_ | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
-| clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
+| clang | 0.3 | 0.3 | using ClangBuildAnalyzer|
 |_command_|`make`; `ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`make`; `ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 
 ## Notes
@@ -1854,7 +1854,7 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 - `conjure_enum`: minimal build
 
 ## Discussion
-For MSVC, `magic_enum` compilation times a slighly better than `conjure_enum` (around %10). For clang the results are identical.
+For MSVC, `magic_enum` compilation times a slighly better than `conjure_enum` (around %9). For clang the results are identical.
 From a compilation performance perspective, `conjure_enum` roughly matches the performance of `magic_enum`.
 
 ---
@@ -1863,7 +1863,7 @@ From a compilation performance perspective, `conjure_enum` roughly matches the p
 | :--- | :--- | :--- | ---: |
 | [gcc](https://gcc.gnu.org/projects/cxx-status.html) | `11`, `12`, `13`, `14`| `std::format` not complete in `11`, `12` | `<= 10` |
 | [clang](https://clang.llvm.org/cxx_status.html) | `15`, `16`, `17`, `18`| Catch2 needs `cxx_std_20` in `15` | `<= 14` |
-| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.0`| `<= 16.9`|
+| [msvc](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance) | `16`, `17` | Visual Studio 2019,2022, latest `17.11.1`| `<= 16.9`|
 | [xcode](https://developer.apple.com/support/xcode/) | `15` | Apple LLVM 15.0.0, some issues with `constexpr`, workarounds| `<= 14`|
 
 # 11. Compiler issues

--- a/README.md
+++ b/README.md
@@ -669,8 +669,8 @@ _output_
 ```
 ## q) `is_scoped`
 ```c++
-struct is_scoped : std::integral_constant<bool, requires
-   { requires !std::is_convertible_v<T, std::underlying_type_t<T>>; }>{};
+struct is_scoped : std::bool_constant<requires
+   { requires !std::convertible_to<T, std::underlying_type_t<T>>; }>{};
 ```
 Returns `true` if the specified enum type is scoped.
 ```c++
@@ -907,7 +907,7 @@ for the bit positions (and names).
 >
 > We decided on these restrictions for both simplicity and practicality - bitsets only really make sense when represented in this manner; also...
 >
-> - This implementation is limited to 64 bits
+> - This implementation is limited to 64 bits (arbitrary length impl. soon).
 
 > [!IMPORTANT]
 > You must include

--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ constexpr enum_bitset() = default;
 constexpr enum_bitset(U bits);
 constexpr enum_bitset(std::string_view from, bool anyscope=false,
    char sep='|', bool ignore_errors=true);
+constexpr enum_bitset(std::bitset<N> from);
 
 template<valid_bitset_enum... E>
 constexpr enum_bitset(E... comp);
@@ -1248,20 +1249,20 @@ not found: 5
 ```c++
 constexpr U get_underlying() const;
 ```
-Returns the underlying integral bitset object.
+Returns the underlying integral value.
 
 ### vii. `get_underlying_bit_size`
 ```c++
 constexpr int get_underlying_bit_size() const
 ```
-Returns the number of bits that the underlying integral contains. Will always be a power of 2. The number of bits may be larger
+Returns the number of bits that the underlying integral contains. Will always be a power of 2 and an integral type. The number of bits may be larger
 than the count of bits.
 
 ### viii. `get_unused_bit_mask`
 ```c++
 constexpr U get_unused_bit_mask() const;
 ```
-Returns a bit mask that would mask off the unused bits of the underlying integral.
+Returns a bit mask that would mask off the _used_ bits of the underlying integral.
 
 ---
 # 5. API and Examples using `conjure_type`

--- a/README.md
+++ b/README.md
@@ -1547,7 +1547,7 @@ struct FIX8::enum_range<range_test>
 static_assert(conjure_enum<range_test>::get_enum_min_value() == 0);
 static_assert(conjure_enum<range_test>::get_enum_max_value() == 7);
 ```
-### iii. `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
+#### `FIX8_CONJURE_ENUM_SET_RANGE_INTS`, `FIX8_CONJURE_ENUM_SET_RANGE`
 For convenience, two macros are provided to make it easier to set custom ranges.
 ```c++
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,min_int,max_int)...
@@ -1562,13 +1562,13 @@ FIX8_CONJURE_ENUM_SET_RANGE_INTS(numbers, 0, 7)
 FIX8_CONJURE_ENUM_SET_RANGE(numbers::first, numbers::eighth)
 ```
 
-### iv. using `T::ce_first` and `T::ce_last`
+### iii. using `T::ce_first` and `T::ce_last`
 Another approach to setting a custom range for an enum is to alias the first and last enum values in your enum definition
 using `ce_first` and `ce_last`. `conjure_enum` will use these values to set the enum range.
 You can set either, both or neither. A range value not set will default to the `FIX8_CONJURE_ENUM_MIN_VALUE` or `FIX8_CONJURE_ENUM_MAX_VALUE`.
 
 > [!WARNING]
-> For unscoped enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined in any translation unit (ODR), due to the open scoping of unscoped
+> With _unscoped_ enums, there can only be one enum type with `T::ce_first` and `T::ce_last` defined in any translation unit (ODR), due to the open scoping of unscoped
 > enums. It is therefore recommended to only use this feature with scoped enums.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -44,18 +44,17 @@
 # 1. Quick links
 ||**Link**|**Description**|
 --|--|--
-|1|[Implementation](include/fix8/conjure_enum.hpp)| For header implementation|
-|2|[`conjure_enum`](#3-conjure_enum)| API and examples|
-|3|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|
-|4|[`conjure_type`](#5-conjure_type)| Any type string extractor|
-|5|[`fixed_string`](#6-fixed_string)| Statically stored null terminated fixed string|
-|6|[Building](#7-building)| How to build or include|
-|7|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
-|8|[Notes](#8-notes)| Notes on the implementation, limits, etc|
-|9|[Benchmarks](#9-benchmarks)| Benchmarking |
-|10|[Compilers](#10-compiler-support)| Supported compilers|
-|11|[Compiler issues](#11-compiler-issues)| Workarounds for various compiler issues|
-|12|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
+|1|[`conjure_enum`](#3-conjure_enum)| API and examples|
+|2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|
+|3|[`conjure_type`](#5-conjure_type)| Any type string extractor|
+|4|[`fixed_string`](#6-fixed_string)| Statically stored null terminated fixed string|
+|5|[Building](#7-building)| How to build or include|
+|6|[vcpkg](https://vcpkg.io/en/package/conjure-enum)| For vcpkg package|
+|7|[Notes](#8-notes)| Notes on the implementation, limits, etc|
+|8|[Benchmarks](#9-benchmarks)| Benchmarking |
+|9|[Compilers](#10-compiler-support)| Supported compilers|
+|10|[Compiler issues](#11-compiler-issues)| Workarounds for various compiler issues|
+|11|[Results of `std::source_location`](reference/source_location.md)| For implementation specific `std::source_location` results|
 > [!TIP]
 > Use the built-in [table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) to navigate this guide.
 > Even better in [full read view](./README.md) of this page.

--- a/README.md
+++ b/README.md
@@ -1462,6 +1462,11 @@ To disable stripping of the executables:
 ```cmake
 cmake -DBUILD_STRIP_EXE=false ..
 ```
+### vi. Default executable stripping
+To enable clang compilation profiling:
+```CMake
+cmake -DBUILD_CLANG_PROFILER=true ..
+```
 ## b) Using in your application with cmake
 In `CMakeLists.txt` set your include path to:
 ```cmake

--- a/README.md
+++ b/README.md
@@ -906,8 +906,10 @@ for the bit positions (and names).
 > - Your enum sequence _must_ be 0 based
 > - Continuous
 > - The last value must be less than the count of enumerations
+>
 > We decided on these restrictions for both simplicity and practicality - bitsets only really make sense when represented in this manner.
-> - this implementation is limited to 64 bits
+>
+> - This implementation is limited to 64 bits
 
 > [!IMPORTANT]
 > You must include

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 > The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most&ensp; $2log_2(N)+O(1)$ &ensp;comparisons.
 > If the array is _not_ sorted, complexity is linear.
 
-The following example uses a `static constexpr` array of pointers to functions. For bevity the most point to the same function except the last which is
+The following example uses a `static constexpr` array of pointers to functions. For brevity they all point to the same function except the last which is
 a lambda.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };
@@ -641,12 +641,14 @@ static constexpr auto tarr
    })
 };
 conjure_enum<directions>::dispatch(directions::right, tarr);
+conjure_enum<directions>::dispatch(directions::down, tarr);
 conjure_enum<directions>::dispatch(directions::forward, tarr);
 std::cout << conjure_enum<directions>::enum_to_int(directions::notfound) << '\n';
 ```
 _output_
 ```CSV
 directions::right
+directions::down
 not found: directions::forward
 -1
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 # 1. Quick links
 ||||
---|--|--
+|--|--|--|
 |1|[`conjure_enum`](#3-conjure_enum)| API and examples|
 |2|[`enum_bitset`](#4-enum_bitset)| Enhanced enum aware `std::bitset`|
 |3|[`conjure_type`](#5-conjure_type)| Any type string extractor|

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ If you wish to pass a `reference` parameter, you must wrap it in `std::ref`.
 If you wish to provide a `constexpr` array, you will need to use a simple function prototype, since `std::function` is not constexpr (see unit tests for examples).
 > [!IMPORTANT]
 > Your `std::array` of `std::tuple` should be sorted by enum.
-> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most $2log_2(N)+O(1)$ comparisons.
+> The `dispatch` method performs a binary search on the array. Complexity for a sorted array is at most  $2log_2(N)+O(1)$  comparisons.
 > If the array is _not_ sorted, complexity is linear.
 ```c++
 enum class directions { left, right, up, down, forward, backward, notfound=-1 };

--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ for the bit positions (and names).
 > - Your enum sequence _must_ be 0 based
 > - Continuous
 > - The last value must be less than the count of enumerations
+> - This implementation is limited to 64 bits
 >
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
 

--- a/README.md
+++ b/README.md
@@ -1474,43 +1474,40 @@ enum_to_string //noscope option not available
 ```
 These are marked ![](assets/notminimalred.svg) in the API documentation above.
 
-## c) Continuous enum optimization
+## c) Using `enum_flags`
 ```c++
-#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+template<valid_enum T>
+struct enum_flags
+{
+   static constexpr bool is_continuous{}, no_anon{};
+};
 ```
-If your enum(s) are continuous (no gaps) you can enable this compiler optimization
-by defining `FIX8_CONJURE_ENUM_IS_CONTINUOUS` _before_ you include `conjure_enum.hpp`.
-Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+You can specialise this class to override the defaults and set your own flags on a per enum basis:
+### i. Continuous enum optimization
+The `is_continuous` flag indicates that your enum(s) are continuous (no gaps). In our testing enabling this compiler optimization
+shows a reduction in overall compile times.
 
-## d) Anonymous enum optimization
-```c++
-#define FIX8_CONJURE_ENUM_NO_ANON
-```
-If your enum(s) are not within any anonymous namespaces (rarely used for this purpose), you can enable this compiler optimization
-by defining `FIX8_CONJURE_ENUM_NO_ANON` _before_ you include `conjure_enum.hpp`.
-Our testing shows a reduction in overall compile times. All enums using `conjure_enum.hpp` in the current compilation unit must be continuous.
+### ii. Anonymous enum optimization
+The `no_anon` indicates flag that your enum(s) are not within any anonymous namespaces (rarely used for this purpose). In our testing enabling this compiler optimization
+shows a reduction in overall compile times.
 
-## e) Enable all optimizations
+### iii. `FIX8_CONJURE_ENUM_SET_FLAGS`
+For convenience, this macro is provided to make it easier to set custom flags. This macro takes an enum typename followed by two `bool` values indicating
+the values of `is_continuous` and `no_anon`.
+
 ```c++
-#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
-```
-You can enable all optimizations described above by defining `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` _before_ you include `conjure_enum.hpp`.
-This is the equivalent of defining:
-```c++
-#define FIX8_CONJURE_ENUM_MINIMAL
-#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
-#define FIX8_CONJURE_ENUM_NO_ANON
+FIX8_CONJURE_ENUM_SET_FLAGS(range_test, true, true)
 ```
 
-## f) Class `conjure_enum` is not constructible
+## d) Class `conjure_enum` is not constructible
 All methods in this class are _static_. You cannot instantiate an object of this type. The same goes for `conjure_type`.
 
-## g) It's not _real_ reflection
+## e) It's not _real_ reflection
 This library provides a workaround (hack :smirk:) to current limitations of C++. There are proposals out there for future versions of the language that will provide proper reflection.
 See [Reflection TS](https://en.cppreference.com/w/cpp/experimental/reflect) and [Reflection for C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html)
 for examples of some of these.
 
-## h) Use of `std::string_view`
+## f) Use of `std::string_view`
 All of the generated static strings and generated static tables obtained by `std::source_location` use the library defined `fixed_string`. No string copying is done at runtime, resulting in
 a single static string in your application. All `conjure_enum` methods that return strings _only_ return `std::string_view`.
 To demonstrate this, lets look at the supplied test application `statictest`:
@@ -1631,7 +1628,7 @@ $
 
 It can be observed that there is only _one_ copy of the scoped enum value string in the executable.
 
-## i) Compilation profiling (Clang)
+## g) Compilation profiling (Clang)
 You can profile the compile time for Clang (other compilers TBA). Firstly install [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).
 Then configure `conjure_enum` with:
 ```CMake

--- a/README.md
+++ b/README.md
@@ -1477,7 +1477,7 @@ These are marked ![](assets/notminimalred.svg) in the API documentation above.
 ## c) Using `enum_flags`
 ```c++
 template<valid_enum T>
-struct enum_flags final
+struct enum_flags
 {
    static constexpr bool is_continuous{}, no_anon{};
 };

--- a/README.md
+++ b/README.md
@@ -1590,9 +1590,9 @@ _output_
 
 ### iv. Which enum limit approach to use
 Compilation times increase with the number of enums that use `conjure_enum` in any compilation unit.
-- For a simple project with few enums, there is probably no need to set any limits.
-- Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros
-- Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`
+1. For a simple project with few enums, there is probably no need to set any limits.
+1. Where the enum is defined elsewhere (say if you are using `std::errc`) then use `enum_range` or one of the convenience macros
+1. Where you have defined the enum yourself and it is a scoped enum, use `T::ce_first` and `T::ce_last`, or 2.
 
 ## b) Choosing the minimal build
 ```c++

--- a/README.md
+++ b/README.md
@@ -1163,10 +1163,10 @@ not found: 5
 The string will be stored statically by the compiler, so you can use the statically generated value `name` to obtain your type.
 > [!IMPORTANT]
 > You must include
-```C++
-#include <fix8/conjure_enum.hpp>
-#include <fix8/conjure_type.hpp>
-```
+> ```C++
+> #include <fix8/conjure_enum.hpp>
+> #include <fix8/conjure_type.hpp>
+> ```
 
 ```c++
 template<typename T>

--- a/README.md
+++ b/README.md
@@ -1373,7 +1373,7 @@ static consteval const char* FIX8::conjure_type<T>::tpeek() [with T = test]
 ---
 # 6. `fixed_string`
 `fixed_string` is a specialisation of `std::array` that provides statics storage for an ASCII zero (asciiz) string. The purpose of this class is to allow the
-creation of `constexpr` strings with specfic storage, adding a trailing `0`. It is used by `conjure_enum` to store all strings. API is described below. Other uses of this class are possible.
+creation of `constexpr` strings with specfic storage, adding a trailing `0`. It is used by `conjure_enum` to store all strings. API is described below.
 
 ## a) Creating a `fixed_string`
 ```c++

--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ for the bit positions (and names).
 > [!WARNING]
 > Your enum _must_ be continuous. The last value must be less than the count of enumerations.
 > We decided on this restriction for both simplicity and practicality - bitsets only really make sense when represented in this manner.
-> [!INFO]
+> [!IMPORTANT]
 > You must include
 ```C++
 #include <fix8/conjure_enum.hpp>

--- a/README.md
+++ b/README.md
@@ -847,9 +847,8 @@ static constexpr auto back();
 These methods return `*cbegin()` and `*std::prev(cend())` respectively all from `entries`
 defined above.
 ```c++
-using en = conjure_enum<numbers>;
-std::cout << static_cast<int>(std::get<0>(en::front())) << ' ' << std::get<1>(en::front()) << '\n';
-std::cout << static_cast<int>(std::get<0>(en::back())) << ' ' << std::get<1>(en::back()) << '\n';
+for (const auto& [ev,str] : {conjure_enum<numbers>::front(), conjure_enum<numbers>::back()})
+   std::cout << static_cast<int>(ev) << ' ' << str << '\n';
 ```
 _output_
 ```CSV

--- a/README.md
+++ b/README.md
@@ -1839,7 +1839,7 @@ For `magic_enum` we created a separate repo (see [here](https://github.com/fix8m
 | Compiler | `conjure_enum` (secs) | `magic_enum` (secs)| Notes |
 | :--- | :--- | :--- |:--- |
 | MSVC | 0.441 | 0.385 | using cl from command prompt|
-| | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp|find "c1xx.dll"`||
+| | `cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp\|find "c1xx.dll"` | `cl /nologo /MD /std:c++latest /Bt+ -I build\_deps\magic_enum-src\include cbenchmark.cpp\|find "c1xx.dll"`||
 | clang | 0.4 | 0.4 | using ClangBuildAnalyzer|
 ||`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang examples/cbenchmark.sh`|`ClangBuildAnalyzerLoc=~/prog/ClangBuildAnalyzer/build ArtifactLoc=build_clang ./cbenchmark.sh`||
 

--- a/README.md
+++ b/README.md
@@ -867,10 +867,10 @@ for the bit positions (and names).
 
 > [!IMPORTANT]
 > You must include
-```C++
-#include <fix8/conjure_enum.hpp>
-#include <fix8/conjure_enum_bitset.hpp>
-```
+> ```C++
+> #include <fix8/conjure_enum.hpp>
+> #include <fix8/conjure_enum_bitset.hpp>
+> ```
 
 ## a) Creating an `enum_bitset`
 ```c++

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -34,6 +34,7 @@
 //----------------------------------------------------------------------------------------
 #include <system_error>
 #define FIX8_CONJURE_ENUM_MINIMAL
+#define FIX8_CONJURE_ENUM_BYPASS
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -38,7 +38,6 @@
 
 //-----------------------------------------------------------------------------------------
 FIX8_CONJURE_ENUM_SET_RANGE_INTS(std::errc, 0, 71)
-FIX8_CONJURE_ENUM_SET_FLAGS(std::errc,true,true)
 
 int test_conjure_enum(std::errc err)
 {

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -33,12 +33,11 @@
 // cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"
 //----------------------------------------------------------------------------------------
 #include <system_error>
-#define FIX8_CONJURE_ENUM_MINIMAL
+#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------
 FIX8_CONJURE_ENUM_SET_RANGE_INTS(std::errc, 0, 71)
-FIX8_CONJURE_ENUM_SET_FLAGS(std::errc,true,true)
 
 int test_conjure_enum(std::errc err)
 {

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -38,6 +38,7 @@
 
 //-----------------------------------------------------------------------------------------
 FIX8_CONJURE_ENUM_SET_RANGE_INTS(std::errc, 0, 71)
+FIX8_CONJURE_ENUM_SET_FLAGS(std::errc,true,true)
 
 int test_conjure_enum(std::errc err)
 {

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -34,7 +34,7 @@
 //----------------------------------------------------------------------------------------
 #include <system_error>
 #define FIX8_CONJURE_ENUM_MINIMAL
-#define FIX8_CONJURE_ENUM_BYPASS
+#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -33,9 +33,7 @@
 // cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"
 //----------------------------------------------------------------------------------------
 #include <system_error>
-#define FIX8_CONJURE_ENUM_MINIMAL
-#define FIX8_CONJURE_ENUM_IS_CONTINUOUS
-#define FIX8_CONJURE_ENUM_NO_ANON
+#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -35,6 +35,7 @@
 #include <system_error>
 #define FIX8_CONJURE_ENUM_MINIMAL
 #define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#define FIX8_CONJURE_ENUM_NO_ANON
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -33,11 +33,12 @@
 // cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"
 //----------------------------------------------------------------------------------------
 #include <system_error>
-#define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+#define FIX8_CONJURE_ENUM_MINIMAL
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------
 FIX8_CONJURE_ENUM_SET_RANGE_INTS(std::errc, 0, 71)
+FIX8_CONJURE_ENUM_SET_FLAGS(std::errc,true,true)
 
 int test_conjure_enum(std::errc err)
 {

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -54,7 +54,7 @@ enum class numbers
 };
 FIX8_CONJURE_ENUM_SET_RANGE(numbers::zero, numbers::sixty_three);
 
-int test_conjure_enum(numbers num)
+auto test_conjure_enum(numbers num)
 {
 	return FIX8::conjure_enum<numbers>::enum_to_string(num).size();
 }

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -28,6 +28,10 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //----------------------------------------------------------------------------------------
+// CLI msvc build benchmark from your build dir
+// call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+// cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"
+//----------------------------------------------------------------------------------------
 #include <system_error>
 #define FIX8_CONJURE_ENUM_MINIMAL
 #include <fix8/conjure_enum.hpp>

--- a/examples/cbenchmark.cpp
+++ b/examples/cbenchmark.cpp
@@ -32,16 +32,31 @@
 // call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 // cl /nologo /MD /std:c++latest /Bt+ /I ..\include  ..\examples\cbenchmark.cpp|find "c1xx.dll"
 //----------------------------------------------------------------------------------------
-#include <system_error>
 #define FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
 #include <fix8/conjure_enum.hpp>
 
 //-----------------------------------------------------------------------------------------
-FIX8_CONJURE_ENUM_SET_RANGE_INTS(std::errc, 0, 71)
-
-int test_conjure_enum(std::errc err)
+enum class numbers
 {
-	return FIX8::conjure_enum<std::errc>::enum_to_string(err).size();
+	zero, one, two, three, four,
+	five, six, seven, eight, nine,
+	ten, eleven, twelve, thirteen, fourteen,
+	fifteen, sixteen, seventeen, eighteen, nineteen,
+	twenty, twenty_one, twenty_two, twenty_three, twenty_four,
+	twenty_five, twenty_six, twenty_seven, twenty_eight, twenty_nine,
+	thirty, thirty_one, thirty_two, thirty_three, thirty_four,
+	thirty_five, thirty_six, thirty_seven, thirty_eight, thirty_nine,
+	forty, forty_one, forty_two, forty_three, forty_four,
+	forty_five, forty_six, forty_seven, forty_eight, forty_nine,
+	fifty, fifty_one, fifty_two, fifty_three, fifty_four,
+	fifty_five, fifty_six, fifty_seven, fifty_eight, fifty_nine,
+	sixty, sixty_one, sixty_two, sixty_three
+};
+FIX8_CONJURE_ENUM_SET_RANGE(numbers::zero, numbers::sixty_three);
+
+int test_conjure_enum(numbers num)
+{
+	return FIX8::conjure_enum<numbers>::enum_to_string(num).size();
 }
 
 int main(void)

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -228,5 +228,7 @@ int main(void)
 	std::cout << '"' << component::host << '"' << '\n';
 	std::cout << '"' << component1::host << '"' << '\n';
 	std::cout << '"' << static_cast<component>(100) << '"' << '\n';
+
+	std::cout << std::hash<enum_bitset<numbers>>{}(er) << '\n';
 	return 0;
 }

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -55,6 +55,24 @@ enum class numbers : int { zero, one, two, three, four, five, six, seven, eight,
 enum class numbers1 : int { zero1=4, one1=3, two1=2, three1, four1, five1, six1, seven1, eight1, nine1 };
 
 //-----------------------------------------------------------------------------------------
+struct foo1
+{
+	int process(component val, int aint) const
+	{
+		return aint * static_cast<int>(val);
+	}
+	static constexpr auto dd2a
+	{
+		std::to_array<std::tuple<component, int (foo1::*)(component, int) const>>
+		({
+			{ component::scheme, &foo1::process },
+			{ component::port, &foo1::process },
+			{ component::fragment, &foo1::process },
+		})
+	};
+};
+
+//-----------------------------------------------------------------------------------------
 template<typename T>
 const std::string demangle() noexcept
 {
@@ -73,6 +91,7 @@ const std::string demangle() noexcept
 	return typeid(T).name();
 }
 
+//-----------------------------------------------------------------------------------------
 int main(void)
 {
 	conjure_enum<component>::for_each_n(3, [](component val, int other) { std::cout << static_cast<int>(val) << ' ' << other << '\n'; }, 200);
@@ -230,5 +249,13 @@ int main(void)
 	std::cout << '"' << static_cast<component>(100) << '"' << '\n';
 
 	std::cout << std::hash<enum_bitset<numbers>>{}(er) << '\n';
+
+	foo1 bar1;
+	std::cout << conjure_enum<component>::dispatch(component::port, -1, foo1::dd2a, &bar1, 1000) << '\n';
+
+	using en = conjure_enum<numbers>;
+	for (const auto& [ev,str] : {en::front(), en::back()})
+		std::cout << static_cast<int>(ev) << ' ' << str << '\n';
+
 	return 0;
 }

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -40,6 +40,8 @@
 #endif
 
 #include <fix8/conjure_enum.hpp>
+#include <fix8/conjure_enum_bitset.hpp>
+#include <fix8/conjure_type.hpp>
 
 //-----------------------------------------------------------------------------------------
 using namespace std::literals::string_view_literals;

--- a/examples/srcloctest.cpp
+++ b/examples/srcloctest.cpp
@@ -152,9 +152,9 @@ int main(int argc, char **argv)
    };
 
 	bool mkd{}, cpl{true}, hlp{};
-	std::map<std::string_view, bool&> opts { {"-m",mkd},{"-c",cpl},{"-h",hlp} };
-	for (int ii{1}; ii < argc; ++ii)
-		if (auto result{opts.find(std::string_view(argv[ii]))}; result != opts.cend())
+	const std::map<std::string_view, bool&> opts { {"-m",mkd},{"-c",cpl},{"-h",hlp} };
+	for (const std::vector<std::string_view> args{argv + 1, argv + argc}; const auto pp : args)
+		if (auto result{opts.find(pp)}; result != opts.cend())
 			result->second ^= true;
 	if (hlp)
 	{

--- a/examples/statictest.cpp
+++ b/examples/statictest.cpp
@@ -44,8 +44,6 @@ int main(void)
 {
 	for(const auto& [a, b] : conjure_enum<component>::entries)
 		std::cout << conjure_enum<component>::enum_to_int(a) << ' ' << b << '\n';
-	for(const auto& a : conjure_enum<component>::names)
-		std::cout << a << '\n';
 	std::cout << static_cast<int>(conjure_enum<component>::string_to_enum("component::path").value()) << '\n';
 	std::cout << conjure_enum<component>::get_enum_min_value() << '/' << conjure_enum<component>::get_enum_max_value() << '\n';
 	return 0;

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -41,6 +41,19 @@
 #endif
 
 //----------------------------------------------------------------------------------------
+#if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+# if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+# endif
+# if not defined FIX8_CONJURE_ENUM_NO_ANON
+#  define FIX8_CONJURE_ENUM_NO_ANON
+# endif
+# if not defined FIX8_CONJURE_ENUM_MINIMAL
+#  define FIX8_CONJURE_ENUM_MINIMAL
+# endif
+#endif
+
+//-----------------------------------------------------------------------------------------
 #include <source_location>
 #include <algorithm>
 #include <string_view>
@@ -54,6 +67,8 @@
 
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
+
+using namespace std::literals::string_view_literals;
 
 //-----------------------------------------------------------------------------------------
 // global default enum range
@@ -109,13 +124,13 @@ class cs final : public static_only
 		std::to_array<std::tuple<std::string_view, char, std::string_view, char>>
 		({
 #if defined __clang__
-			{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' },
+			{ "e = "sv, ']', "(anonymous namespace)"sv, '(' }, { "T = "sv, ']', "(anonymous namespace)"sv, '(' },
 #elif defined __GNUC__
-			{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' },
+			{ "e = "sv, ';', "<unnamed>"sv, '<' }, { "T = "sv, ']', "{anonymous}"sv, '{' },
 #elif defined _MSC_VER
-			{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
-			{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
-			{ "", '\0', "struct ", '\0' },
+			{ "epeek<"sv, '>', "`anonymous-namespace'"sv, '`' }, { "::tpeek"sv, '<', "enum `anonymous namespace'::"sv, '\0' },
+			{ ""sv, '\0', "`anonymous namespace'::"sv, '\0' }, { ""sv, '\0', "enum "sv, '\0' }, { ""sv, '\0', "class "sv, '\0' },
+			{ ""sv, '\0', "struct "sv, '\0' },
 #else
 # error "conjure_enum not supported by your compiler"
 #endif
@@ -137,7 +152,7 @@ using stype = cs::stype;
 using sval = cs::sval;
 
 #if defined _MSC_VER
-#define CHKMSSTR(e,x) \
+#define CHKMSSTR(e, x) \
 	if constexpr (constexpr auto ep##x { e.find(cs::get_spec<sval::anon_str,stype::x>()) }; ep##x != std::string_view::npos) \
 		return e.substr(ep##x + cs::get_spec<sval::anon_str,stype::x>().size(), e.size() - (ep##x + cs::get_spec<sval::anon_str,stype::x>().size()))
 #endif
@@ -163,27 +178,10 @@ struct enum_range final : public static_only
 // Convenience macros for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,minv,maxv) \
-	template<> struct FIX8::enum_range<ec> final : public FIX8::static_only \
-		{ static constexpr int min{minv}, max{maxv}; };
+	template<> struct FIX8::enum_range<ec> { static constexpr int min{minv}, max{maxv}; };
 
 #define FIX8_CONJURE_ENUM_SET_RANGE(minv,maxv) \
-	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv), static_cast<int>(minv), static_cast<int>(maxv))
-
-//-----------------------------------------------------------------------------------------
-// You can specialise this class to define custom flags for your enum
-//-----------------------------------------------------------------------------------------
-template<valid_enum T>
-struct enum_flags final : public static_only
-{
-	static constexpr bool is_continuous{}, no_anon{};
-};
-
-//-----------------------------------------------------------------------------------------
-// Convenience macro for above
-//-----------------------------------------------------------------------------------------
-#define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> final : public FIX8::static_only \
-		{ static constexpr int is_continuous{iscont}, no_anon{noanon}; };
+	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>
@@ -216,9 +214,10 @@ private:
 		{
 			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
-			if constexpr (!enum_flags<T>::no_anon)
-				if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
-					return true;
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
+			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
+				return true;
+#endif
 		}
 		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
@@ -235,22 +234,19 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-		if constexpr (enum_flags<T>::is_continuous)
-		{
-			static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-			return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
-		}
-		else
-		{
-			constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
-			constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
-			static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
-			std::array<T, valid_cnt> vals{};
-			for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
-				if (valid[idx])
-					vals[nn++] = static_cast<T>(enum_min_value + idx);
-			return vals;
-		}
+#if defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
+		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
+#else
+		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
+		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
+		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
+		std::array<T, valid_cnt> vals{};
+		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
+			if (valid[idx])
+				vals[nn++] = static_cast<T>(enum_min_value + idx);
+		return vals;
+#endif
 	}
 
 	template<T e>
@@ -259,20 +255,19 @@ private:
 		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
-		if constexpr (!enum_flags<T>::no_anon)
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
+		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
 		{
-			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
-			{
 #if defined __clang__
-				if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
-					return {};
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
+				return {};
 #endif
-				if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-					lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
-						if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-							return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
-			}
+			if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
+					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
+#endif
 		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -281,6 +281,19 @@ private:
 	template<T e>
 	static constexpr auto _enum_name_v { fixed_string<_get_name_v<e>.size()>(_get_name_v<e>) };
 
+	template<std::size_t... I>
+	static constexpr auto _entries(std::index_sequence<I...>) noexcept
+	{
+		return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};
+	}
+
+	static constexpr auto _sorted_entries() noexcept
+	{
+		auto tmp { entries };
+		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
+		return tmp;
+	}
+
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
@@ -378,15 +391,8 @@ public:
 
 	// public constexpr data structures
 	static constexpr auto values { _values(std::make_index_sequence<enum_max_value - enum_min_value + 1>()) };
-	static constexpr auto entries { []<std::size_t... I>(std::index_sequence<I...>) noexcept
-		{ return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};}(std::make_index_sequence<values.size()>()) };
-	static constexpr auto sorted_entries { []() noexcept
-	{
-		auto tmp { entries };
-		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
-		return tmp;
-	}()};
-
+	static constexpr auto entries { _entries(std::make_index_sequence<values.size()>()) };
+	static constexpr auto sorted_entries { _sorted_entries() };
 
 	// misc
 	static constexpr int get_enum_min_value() noexcept { return enum_min_value; }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -281,6 +281,19 @@ private:
 	template<T e>
 	static constexpr auto _enum_name_v { fixed_string<_get_name_v<e>.size()>(_get_name_v<e>) };
 
+	template<std::size_t... I>
+	static constexpr auto _entries(std::index_sequence<I...>) noexcept
+	{
+		return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};
+	}
+
+	static constexpr auto _sorted_entries() noexcept
+	{
+		auto tmp { entries };
+		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
+		return tmp;
+	}
+
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
@@ -378,10 +391,8 @@ public:
 
 	// public constexpr data structures
 	static constexpr auto values { _values(std::make_index_sequence<enum_max_value - enum_min_value + 1>()) };
-	static constexpr auto entries { []<std::size_t... I>(std::index_sequence<I...>) noexcept
-		{ return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};}(std::make_index_sequence<values.size()>()) };
-	static constexpr auto sorted_entries { []() noexcept
-		{ auto tmp { entries }; std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev); return tmp; }()};
+	static constexpr auto entries { _entries(std::make_index_sequence<values.size()>()) };
+	static constexpr auto sorted_entries { _sorted_entries() };
 
 	// misc
 	static constexpr int get_enum_min_value() noexcept { return enum_min_value; }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -82,19 +82,17 @@ using namespace std::literals::string_view_literals;
 
 //-----------------------------------------------------------------------------------------
 template<std::size_t N>
-class fixed_string final
+class fixed_string final : public std::array<char, N + 1>
 {
-	const std::array<char, N + 1> _buff;
 	template<std::size_t... C>
-	constexpr fixed_string(std::string_view sv, std::index_sequence<C...>) noexcept : _buff{sv[C]..., 0} {}
+	constexpr fixed_string(std::string_view sv, std::index_sequence<C...>) noexcept : std::array<char, N + 1>{sv[C]..., 0} {}
 
 public:
 	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv, std::make_index_sequence<N>{}} {}
 	constexpr fixed_string() = delete;
-	constexpr std::string_view get() const noexcept { return { _buff.data(), N }; }
+	constexpr std::string_view get() const noexcept { return { this->data(), N }; }
+	constexpr const char *c_str() const noexcept { return this->data(); }
 	constexpr operator std::string_view() const noexcept { return get(); }
-	constexpr char operator[](size_t idx) const noexcept { return _buff[idx]; }
-	constexpr std::size_t size() const noexcept { return _buff.size(); }
 	friend std::ostream& operator<<(std::ostream& os, const fixed_string& what) noexcept { return os << what.get(); }
 };
 

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -47,6 +47,17 @@
 #include <tuple>
 #include <concepts>
 #include <optional>
+#if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+# if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+# endif
+# if not defined FIX8_CONJURE_ENUM_NO_ANON
+#  define FIX8_CONJURE_ENUM_NO_ANON
+# endif
+# if not defined FIX8_CONJURE_ENUM_MINIMAL
+#  define FIX8_CONJURE_ENUM_MINIMAL
+# endif
+#endif
 #if not defined FIX8_CONJURE_ENUM_MINIMAL
 # include <functional>
 #endif

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -105,6 +105,7 @@ protected:
 //-----------------------------------------------------------------------------------------
 class cs : public static_only
 {
+	/*
 	static constexpr auto _specifics
 	{
 		std::to_array<std::tuple<std::string_view, char, std::string_view, char>>
@@ -122,6 +123,28 @@ class cs : public static_only
 #endif
 		})
 	};
+	*/
+
+#if defined __clang__
+	static constexpr std::array<std::tuple<std::string_view, char, std::string_view, char>, 2> _specifics
+	{
+		{{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' }},
+	};
+#elif defined __GNUC__
+	static constexpr std::array<std::tuple<std::string_view, char, std::string_view, char>, 2> _specifics
+	{
+		{{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' }},
+	};
+#elif defined _MSC_VER
+	static constexpr std::array<std::tuple<std::string_view, char, std::string_view, char>, 6> _specifics
+	{
+		{{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
+		{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
+		{ "", '\0', "struct ", '\0' }},
+	};
+#else
+# error "conjure_enum not supported by your compiler"
+#endif
 
 public:
 	enum class stype { enum_t, type_t, extype_t0, extype_t1, extype_t2, extype_t3 };

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -195,7 +195,7 @@ class conjure_enum : public static_only
 {
 	static constexpr int enum_min_value{enum_range<T>::min}, enum_max_value{enum_range<T>::max};
 	static_assert(enum_max_value > enum_min_value,
-		"FIX8_CONJURE_ENUM_MAX_VALUE, enum_range<T>::max or T::ce_first must be greater than FIX8_CONJURE_ENUM_MIN_VALUE, enum_range<T>::min or T::ce_last) ");
+		"FIX8_CONJURE_ENUM_MAX_VALUE, enum_range<T>::max or T::ce_last must be greater than FIX8_CONJURE_ENUM_MIN_VALUE, enum_range<T>::min or T::ce_first) ");
 
 public:
 	using enum_tuple = std::tuple<T, std::string_view>;

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -251,11 +251,11 @@ private:
 		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
 			if (valid[idx])
 				vals[nn++] = static_cast<T>(enum_min_value + idx);
+		return vals;
 #else
 		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-		std::array<T, sizeof...(I)> vals{static_cast<T>(enum_min_value + I)... };
+		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
 #endif
-		return vals;
 	}
 
 	template<T e>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -72,12 +72,12 @@ using namespace std::literals::string_view_literals;
 template<std::size_t N>
 class fixed_string final
 {
-	std::array<char, N + 1> _buff;
+	const std::array<char, N + 1> _buff;
 	template<char... C>
-	constexpr fixed_string(const char *pp, std::integer_sequence<char, C...>) noexcept : _buff{*(pp + C)..., 0} {}
+	constexpr fixed_string(std::string_view sv, std::integer_sequence<char, C...>) noexcept : _buff{sv[C]..., 0} {}
 
 public:
-	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv.data(), std::make_integer_sequence<char, N>{}} {}
+	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv, std::make_integer_sequence<char, N>{}} {}
 	constexpr fixed_string() = delete;
 	constexpr std::string_view get() const noexcept { return { _buff.data(), N }; }
 	constexpr operator std::string_view() const noexcept { return get(); }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -163,7 +163,7 @@ struct enum_range final : public static_only
 // Convenience macros for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,minv,maxv) \
-	template<> struct FIX8::enum_range<ec> : public static_only { static constexpr int min{minv}, max{maxv}; };
+	template<> struct FIX8::enum_range<ec> : public FIX8::static_only { static constexpr int min{minv}, max{maxv}; };
 
 #define FIX8_CONJURE_ENUM_SET_RANGE(minv,maxv) \
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
@@ -181,7 +181,7 @@ struct enum_flags final : public static_only
 // Convenience macro for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> : public static_only { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
+	template<> struct FIX8::enum_flags<ec> : public FIX8::static_only { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -41,6 +41,19 @@
 #endif
 
 //----------------------------------------------------------------------------------------
+#if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+# if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+# endif
+# if not defined FIX8_CONJURE_ENUM_NO_ANON
+#  define FIX8_CONJURE_ENUM_NO_ANON
+# endif
+# if not defined FIX8_CONJURE_ENUM_MINIMAL
+#  define FIX8_CONJURE_ENUM_MINIMAL
+# endif
+#endif
+
+//-----------------------------------------------------------------------------------------
 #include <source_location>
 #include <algorithm>
 #include <string_view>
@@ -54,6 +67,8 @@
 
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
+
+using namespace std::literals::string_view_literals;
 
 //-----------------------------------------------------------------------------------------
 // global default enum range
@@ -109,13 +124,13 @@ class cs final : public static_only
 		std::to_array<std::tuple<std::string_view, char, std::string_view, char>>
 		({
 #if defined __clang__
-			{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' },
+			{ "e = "sv, ']', "(anonymous namespace)"sv, '(' }, { "T = "sv, ']', "(anonymous namespace)"sv, '(' },
 #elif defined __GNUC__
-			{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' },
+			{ "e = "sv, ';', "<unnamed>"sv, '<' }, { "T = "sv, ']', "{anonymous}"sv, '{' },
 #elif defined _MSC_VER
-			{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
-			{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
-			{ "", '\0', "struct ", '\0' },
+			{ "epeek<"sv, '>', "`anonymous-namespace'"sv, '`' }, { "::tpeek"sv, '<', "enum `anonymous namespace'::"sv, '\0' },
+			{ ""sv, '\0', "`anonymous namespace'::"sv, '\0' }, { ""sv, '\0', "enum "sv, '\0' }, { ""sv, '\0', "class "sv, '\0' },
+			{ ""sv, '\0', "struct "sv, '\0' },
 #else
 # error "conjure_enum not supported by your compiler"
 #endif
@@ -169,21 +184,6 @@ struct enum_range final : public static_only
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
 
 //-----------------------------------------------------------------------------------------
-// You can specialise this class to define custom flags for your enum
-//-----------------------------------------------------------------------------------------
-template<valid_enum T>
-struct enum_flags final : public static_only
-{
-	static constexpr bool is_continuous{}, no_anon{};
-};
-
-//-----------------------------------------------------------------------------------------
-// Convenience macro for above
-//-----------------------------------------------------------------------------------------
-#define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
-
-//-----------------------------------------------------------------------------------------
 template<valid_enum T>
 class conjure_enum final : public static_only
 {
@@ -214,9 +214,10 @@ private:
 		{
 			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
-			if constexpr (!enum_flags<T>::no_anon)
-				if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
-					return true;
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
+			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
+				return true;
+#endif
 		}
 		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
@@ -233,22 +234,19 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-		if constexpr (enum_flags<T>::is_continuous)
-		{
-			static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-			return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
-		}
-		else
-		{
-			constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
-			constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
-			static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
-			std::array<T, valid_cnt> vals{};
-			for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
-				if (valid[idx])
-					vals[nn++] = static_cast<T>(enum_min_value + idx);
-			return vals;
-		}
+#if defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
+		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
+#else
+		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
+		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
+		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
+		std::array<T, valid_cnt> vals{};
+		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
+			if (valid[idx])
+				vals[nn++] = static_cast<T>(enum_min_value + idx);
+		return vals;
+#endif
 	}
 
 	template<T e>
@@ -257,20 +255,19 @@ private:
 		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
-		if constexpr (!enum_flags<T>::no_anon)
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
+		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
 		{
-			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
-			{
 #if defined __clang__
-				if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
-					return {};
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
+				return {};
 #endif
-				if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-					lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
-						if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-							return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
-			}
+			if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
+					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
+#endif
 		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -163,7 +163,7 @@ struct enum_range final : public static_only
 // Convenience macros for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,minv,maxv) \
-	template<> struct FIX8::enum_range<ec> { static constexpr int min{minv}, max{maxv}; };
+	template<> struct FIX8::enum_range<ec> : public static_only { static constexpr int min{minv}, max{maxv}; };
 
 #define FIX8_CONJURE_ENUM_SET_RANGE(minv,maxv) \
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
@@ -181,7 +181,7 @@ struct enum_flags final : public static_only
 // Convenience macro for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
+	template<> struct FIX8::enum_flags<ec> : public static_only { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -339,17 +339,19 @@ public:
 	}
 	static constexpr std::optional<T> int_to_enum(int value) noexcept
 	{
-		if (const auto [begin,end] { std::equal_range(values.cbegin(), values.cend(), static_cast<T>(value), _value_comp) };
-			begin != end)
-				return *begin;
+		if (const auto result { std::equal_range(values.cbegin(), values.cend(), static_cast<T>(value), _value_comp) };
+			result.first != result.second)
+				return *result.first;
 		return {};
 	}
 
 	// index
 	static constexpr std::optional<size_t> index(T value) noexcept
 	{
-		const auto [begin,end] { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
-		return begin != end ? &*begin - &*entries.cbegin() : std::optional<size_t>{};
+		if (const auto result { std::equal_range(values.cbegin(), values.cend(), value, _value_comp) };
+			result.first != result.second)
+				return &*result.first - &*values.cbegin();
+		return {};
 	}
 	template<T e>
 	static constexpr std::optional<size_t> index() noexcept { return index(e); }
@@ -372,21 +374,23 @@ public:
 
 	static constexpr std::string_view enum_to_string(T value, [[maybe_unused]] bool noscope=false) noexcept
 	{
-		if (const auto [begin,end] { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
-			begin != end)
+		if (const auto result { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
+			result.first != result.second)
 		{
 #if not defined FIX8_CONJURE_ENUM_MINIMAL
 			if (noscope)
-				return remove_scope(std::get<std::string_view>(*begin));
+				return remove_scope(std::get<std::string_view>(*result.first));
 #endif
-			return std::get<std::string_view>(*begin);
+			return std::get<std::string_view>(*result.first);
 		}
 		return {};
 	}
 	static constexpr std::optional<T> string_to_enum(std::string_view str) noexcept
 	{
-		const auto [begin,end] { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
-		return begin != end ? std::get<T>(*begin) : std::optional<T>{};
+		if (const auto result { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
+			result.first != result.second)
+				return std::get<T>(*result.first);
+		return {};
 	}
 
 	// public constexpr data structures

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -243,7 +243,10 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-#if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#if defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
+		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
+#else
 		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
 		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
 		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
@@ -252,9 +255,6 @@ private:
 			if (valid[idx])
 				vals[nn++] = static_cast<T>(enum_min_value + idx);
 		return vals;
-#else
-		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
 #endif
 	}
 

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -181,10 +181,10 @@ public:
 	using enum_tuple = std::tuple<T, std::string_view>;
 	using scoped_tuple = std::tuple<std::string_view, std::string_view>;
 
-	static constexpr const char *tpeek() noexcept { return std::source_location::current().function_name(); }
+	static consteval const char *tpeek() noexcept { return std::source_location::current().function_name(); }
 
 	template<T e>
-	static constexpr const char *epeek() noexcept { return std::source_location::current().function_name(); }
+	static consteval const char *epeek() noexcept { return std::source_location::current().function_name(); }
 
 private:
 	template<T e>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -82,17 +82,20 @@ using namespace std::literals::string_view_literals;
 
 //-----------------------------------------------------------------------------------------
 template<std::size_t N>
-class fixed_string final : public std::array<char, N + 1>
+class fixed_string final
 {
+	const std::array<char, N + 1> _buff;
 	template<std::size_t... C>
-	constexpr fixed_string(std::string_view sv, std::index_sequence<C...>) noexcept : std::array<char, N + 1>{sv[C]..., 0} {}
+	constexpr fixed_string(std::string_view sv, std::index_sequence<C...>) noexcept : _buff{sv[C]..., 0} {}
 
 public:
 	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv, std::make_index_sequence<N>{}} {}
 	constexpr fixed_string() = delete;
-	constexpr std::string_view get() const noexcept { return { this->data(), N }; }
-	constexpr const char *c_str() const noexcept { return this->data(); }
+	constexpr std::string_view get() const noexcept { return { _buff.data(), N }; }
+	constexpr const char *c_str() const noexcept { return _buff.data(); }
 	constexpr operator std::string_view() const noexcept { return get(); }
+	constexpr char operator[](size_t idx) const noexcept { return _buff[idx]; }
+	constexpr std::size_t size() const noexcept { return _buff.size(); }
 	friend std::ostream& operator<<(std::ostream& os, const fixed_string& what) noexcept { return os << what.get(); }
 };
 

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -137,7 +137,7 @@ using stype = cs::stype;
 using sval = cs::sval;
 
 #if defined _MSC_VER
-#define CHKMSSTR(e, x) \
+#define CHKMSSTR(e,x) \
 	if constexpr (constexpr auto ep##x { e.find(cs::get_spec<sval::anon_str,stype::x>()) }; ep##x != std::string_view::npos) \
 		return e.substr(ep##x + cs::get_spec<sval::anon_str,stype::x>().size(), e.size() - (ep##x + cs::get_spec<sval::anon_str,stype::x>().size()))
 #endif
@@ -163,10 +163,11 @@ struct enum_range final : public static_only
 // Convenience macros for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,minv,maxv) \
-	template<> struct FIX8::enum_range<ec> : public FIX8::static_only { static constexpr int min{minv}, max{maxv}; };
+	template<> struct FIX8::enum_range<ec> final : public FIX8::static_only \
+		{ static constexpr int min{minv}, max{maxv}; };
 
 #define FIX8_CONJURE_ENUM_SET_RANGE(minv,maxv) \
-	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
+	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv), static_cast<int>(minv), static_cast<int>(maxv))
 
 //-----------------------------------------------------------------------------------------
 // You can specialise this class to define custom flags for your enum
@@ -181,7 +182,8 @@ struct enum_flags final : public static_only
 // Convenience macro for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> : public FIX8::static_only { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
+	template<> struct FIX8::enum_flags<ec> final : public FIX8::static_only \
+		{ static constexpr int is_continuous{iscont}, no_anon{noanon}; };
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -365,7 +365,8 @@ public:
 	{
 		if constexpr (is_continuous())
 			return in_range(value);
-		return std::binary_search(values.cbegin(), values.cend(), value, _value_comp);
+		else
+			return std::binary_search(values.cbegin(), values.cend(), value, _value_comp);
    }
 	static constexpr bool contains(std::string_view str) noexcept
 	{

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -339,12 +339,7 @@ public:
 	}
 	static constexpr std::optional<T> int_to_enum(int value) noexcept
 	{
-		if constexpr (is_continuous())
-			return in_range(static_cast<T>(value)) ? static_cast<T>(value) : std::optional<T>{};
-		if (const auto [begin,end] { std::equal_range(values.cbegin(), values.cend(), static_cast<T>(value), _value_comp) };
-			begin != end)
-				return *begin;
-		return {};
+		return contains(static_cast<T>(value)) ? static_cast<T>(value) : std::optional<T>{};
 	}
 
 	// index

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -241,6 +241,7 @@ private:
 		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
 		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
 		{
 #if defined __clang__
@@ -252,6 +253,7 @@ private:
 					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
+#endif
 		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -434,6 +434,17 @@ public:
 		return {};
 	}
 
+	// index
+	static constexpr std::optional<size_t> index(T value) noexcept
+	{
+		if (const auto result { std::equal_range(values.cbegin(), values.cend(), value, _value_comp) };
+			result.first != result.second)
+				return &*result.first - &*values.cbegin();
+		return {};
+	}
+	template<T e>
+	static constexpr std::optional<size_t> index() noexcept { return index(e); }
+
 	// contains
 	static constexpr bool contains(T value) noexcept
 	{
@@ -445,6 +456,8 @@ public:
 		const auto result { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
 		return result.first != result.second;
 	}
+	template<T e>
+	static constexpr bool contains() noexcept { return contains(e); }
 
 	// string <==> enum
 	template<T e>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -302,9 +302,6 @@ public:
 		requires !std::convertible_to<T, std::underlying_type_t<T>>;
 	}>{};
 
-	template<T e>
-	static constexpr bool is_valid() noexcept { return _is_valid<e>(); }
-
 	static constexpr auto count() noexcept { return values.size(); }
 
 	// scope ops

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -141,10 +141,7 @@ public:
 	enum class sval { start, end, anon_str, anon_start };
 
 	template<sval N, stype V> // can't have constexpr decompositions! (but why not?)
-	static constexpr auto get_spec() noexcept
-	{
-		return std::get<static_cast<int>(N)>(_specifics[static_cast<int>(V)]);
-	}
+	static constexpr auto get_spec() noexcept { return std::get<static_cast<int>(N)>(_specifics[static_cast<int>(V)]); }
 	static constexpr auto size() noexcept { return sizeof(_specifics); }
 };
 using stype = cs::stype;

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -351,8 +351,11 @@ public:
 	{
 		if constexpr (is_continuous())
 			return in_range(value) ? enum_to_underlying(value) - enum_to_underlying(min_v) : std::optional<size_t>{};
-		const auto [begin,end] { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
-		return begin != end ? &*begin - &*entries.cbegin() : std::optional<size_t>{};
+		else
+		{
+			const auto [begin,end] { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
+			return begin != end ? &*begin - &*entries.cbegin() : std::optional<size_t>{};
+		}
 	}
 	template<T e>
 	static constexpr std::optional<size_t> index() noexcept { return index(e); }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -41,19 +41,6 @@
 #endif
 
 //----------------------------------------------------------------------------------------
-#if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
-# if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
-#  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
-# endif
-# if not defined FIX8_CONJURE_ENUM_NO_ANON
-#  define FIX8_CONJURE_ENUM_NO_ANON
-# endif
-# if not defined FIX8_CONJURE_ENUM_MINIMAL
-#  define FIX8_CONJURE_ENUM_MINIMAL
-# endif
-#endif
-
-//-----------------------------------------------------------------------------------------
 #include <source_location>
 #include <algorithm>
 #include <string_view>
@@ -67,8 +54,6 @@
 
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
-
-using namespace std::literals::string_view_literals;
 
 //-----------------------------------------------------------------------------------------
 // global default enum range
@@ -124,13 +109,13 @@ class cs final : public static_only
 		std::to_array<std::tuple<std::string_view, char, std::string_view, char>>
 		({
 #if defined __clang__
-			{ "e = "sv, ']', "(anonymous namespace)"sv, '(' }, { "T = "sv, ']', "(anonymous namespace)"sv, '(' },
+			{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' },
 #elif defined __GNUC__
-			{ "e = "sv, ';', "<unnamed>"sv, '<' }, { "T = "sv, ']', "{anonymous}"sv, '{' },
+			{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' },
 #elif defined _MSC_VER
-			{ "epeek<"sv, '>', "`anonymous-namespace'"sv, '`' }, { "::tpeek"sv, '<', "enum `anonymous namespace'::"sv, '\0' },
-			{ ""sv, '\0', "`anonymous namespace'::"sv, '\0' }, { ""sv, '\0', "enum "sv, '\0' }, { ""sv, '\0', "class "sv, '\0' },
-			{ ""sv, '\0', "struct "sv, '\0' },
+			{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
+			{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
+			{ "", '\0', "struct ", '\0' },
 #else
 # error "conjure_enum not supported by your compiler"
 #endif
@@ -178,10 +163,25 @@ struct enum_range final : public static_only
 // Convenience macros for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,minv,maxv) \
-	template<> struct FIX8::enum_range<ec> { static constexpr int min{minv}, max{maxv}; };
+	template<> struct FIX8::enum_range<ec> : public static_only { static constexpr int min{minv}, max{maxv}; };
 
 #define FIX8_CONJURE_ENUM_SET_RANGE(minv,maxv) \
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
+
+//-----------------------------------------------------------------------------------------
+// You can specialise this class to define custom flags for your enum
+//-----------------------------------------------------------------------------------------
+template<valid_enum T>
+struct enum_flags final : public static_only
+{
+	static constexpr bool is_continuous{}, no_anon{};
+};
+
+//-----------------------------------------------------------------------------------------
+// Convenience macro for above
+//-----------------------------------------------------------------------------------------
+#define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
+	template<> struct FIX8::enum_flags<ec> : public static_only { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>
@@ -214,10 +214,9 @@ private:
 		{
 			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
-#if not defined FIX8_CONJURE_ENUM_NO_ANON
-			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
-				return true;
-#endif
+			if constexpr (!enum_flags<T>::no_anon)
+				if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
+					return true;
 		}
 		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
@@ -234,19 +233,22 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-#if defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
-		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
-#else
-		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
-		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
-		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
-		std::array<T, valid_cnt> vals{};
-		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
-			if (valid[idx])
-				vals[nn++] = static_cast<T>(enum_min_value + idx);
-		return vals;
-#endif
+		if constexpr (enum_flags<T>::is_continuous)
+		{
+			static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
+			return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
+		}
+		else
+		{
+			constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
+			constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
+			static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
+			std::array<T, valid_cnt> vals{};
+			for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
+				if (valid[idx])
+					vals[nn++] = static_cast<T>(enum_min_value + idx);
+			return vals;
+		}
 	}
 
 	template<T e>
@@ -255,19 +257,20 @@ private:
 		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
-#if not defined FIX8_CONJURE_ENUM_NO_ANON
-		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
+		if constexpr (!enum_flags<T>::no_anon)
 		{
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
+			{
 #if defined __clang__
-			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
-				return {};
+				if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
+					return {};
 #endif
-			if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
-					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
+				if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+					lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
+						if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+							return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
+			}
 		}
-#endif
 		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -41,19 +41,6 @@
 #endif
 
 //----------------------------------------------------------------------------------------
-#if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
-# if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
-#  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
-# endif
-# if not defined FIX8_CONJURE_ENUM_NO_ANON
-#  define FIX8_CONJURE_ENUM_NO_ANON
-# endif
-# if not defined FIX8_CONJURE_ENUM_MINIMAL
-#  define FIX8_CONJURE_ENUM_MINIMAL
-# endif
-#endif
-
-//-----------------------------------------------------------------------------------------
 #include <source_location>
 #include <algorithm>
 #include <string_view>
@@ -184,6 +171,21 @@ struct enum_range final : public static_only
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
 
 //-----------------------------------------------------------------------------------------
+// You can specialise this class to define custom flags for your enum
+//-----------------------------------------------------------------------------------------
+template<valid_enum T>
+struct enum_flags final : public static_only
+{
+	static constexpr bool is_continuous{}, no_anon{};
+};
+
+//-----------------------------------------------------------------------------------------
+// Convenience macros for above
+//-----------------------------------------------------------------------------------------
+#define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
+	template<> struct FIX8::enum_flags<ec> { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
+
+//-----------------------------------------------------------------------------------------
 template<valid_enum T>
 class conjure_enum final : public static_only
 {
@@ -214,10 +216,9 @@ private:
 		{
 			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
-#if not defined FIX8_CONJURE_ENUM_NO_ANON
-			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
-				return true;
-#endif
+			if constexpr (!enum_flags<T>::no_anon)
+				if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
+					return true;
 		}
 		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
@@ -234,19 +235,22 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-#if defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
-		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
-#else
-		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
-		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
-		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
-		std::array<T, valid_cnt> vals{};
-		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
-			if (valid[idx])
-				vals[nn++] = static_cast<T>(enum_min_value + idx);
-		return vals;
-#endif
+		if constexpr (enum_flags<T>::is_continuous)
+		{
+			static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
+			return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
+		}
+		else
+		{
+			constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
+			constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
+			static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
+			std::array<T, valid_cnt> vals{};
+			for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
+				if (valid[idx])
+					vals[nn++] = static_cast<T>(enum_min_value + idx);
+			return vals;
+		}
 	}
 
 	template<T e>
@@ -255,19 +259,20 @@ private:
 		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
-#if not defined FIX8_CONJURE_ENUM_NO_ANON
-		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
+		if constexpr (!enum_flags<T>::no_anon)
 		{
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
+			{
 #if defined __clang__
-			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
-				return {};
+				if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
+					return {};
 #endif
-			if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
-					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
+				if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+					lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
+						if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+							return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
+			}
 		}
-#endif
 		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -85,11 +85,11 @@ template<std::size_t N>
 class fixed_string final
 {
 	const std::array<char, N + 1> _buff;
-	template<char... C>
-	constexpr fixed_string(std::string_view sv, std::integer_sequence<char, C...>) noexcept : _buff{sv[C]..., 0} {}
+	template<std::size_t... C>
+	constexpr fixed_string(std::string_view sv, std::index_sequence<C...>) noexcept : _buff{sv[C]..., 0} {}
 
 public:
-	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv, std::make_integer_sequence<char, N>{}} {}
+	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv, std::make_index_sequence<N>{}} {}
 	constexpr fixed_string() = delete;
 	constexpr std::string_view get() const noexcept { return { _buff.data(), N }; }
 	constexpr operator std::string_view() const noexcept { return get(); }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -212,6 +212,7 @@ private:
 		if constexpr (constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::enum_t>()) }; ep == std::string_view::npos)
 			return false;
 #if defined __clang__
+#if not defined FIX8_CONJURE_ENUM_MINIMAL
 		else if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == '(')
 		{
 			if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
@@ -220,6 +221,7 @@ private:
 				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
 					return true;
 		}
+#endif
 		else if constexpr (from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).find_first_of(cs::get_spec<sval::end,stype::enum_t>()) != std::string_view::npos)
 			return true;
 		return false;
@@ -252,6 +254,7 @@ private:
 		constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
+#if not defined FIX8_CONJURE_ENUM_MINIMAL
 		if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
 		{
 #if defined __clang__
@@ -263,6 +266,7 @@ private:
 					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
+#endif
 		constexpr std::string_view result { from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);
@@ -289,33 +293,6 @@ public:
 
 	template<T e>
 	static consteval const char *epeek() noexcept { return std::source_location::current().function_name(); }
-
-	static constexpr std::string_view type_name() noexcept
-	{
-		constexpr std::string_view from{tpeek()};
-#if defined _MSC_VER
-		constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::type_t>()) };
-		if constexpr (ep == std::string_view::npos)
-			return {};
-		if constexpr (constexpr auto lc { from.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
-		{
-			constexpr auto e1 { from.substr(lc + 1, ep - lc - 2) };
-			CHKMSSTR(e1,type_t);
-			CHKMSSTR(e1,extype_t1);
-		}
-		else
-			return {};
-#else
-		if constexpr (constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::type_t>()) }; ep != std::string_view::npos)
-		{
-			constexpr auto result { from.substr(ep + cs::get_spec<sval::start,stype::type_t>().size()) };
-			if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
-				return result.substr(0, lc);
-		}
-		else
-			return {};
-#endif
-	}
 
 	struct is_scoped : std::bool_constant<requires
 	{

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -243,7 +243,7 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-#if not defined FIX8_CONJURE_ENUM_BYPASS
+#if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
 		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
 		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
 		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
@@ -252,6 +252,7 @@ private:
 			if (valid[idx])
 				vals[nn++] = static_cast<T>(enum_min_value + idx);
 #else
+		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
 		std::array<T, sizeof...(I)> vals{static_cast<T>(enum_min_value + I)... };
 #endif
 		return vals;

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -103,48 +103,26 @@ protected:
 //-----------------------------------------------------------------------------------------
 // compiler specifics
 //-----------------------------------------------------------------------------------------
+	using namespace std::literals::string_view_literals;
 class cs : public static_only
 {
-	/*
 	static constexpr auto _specifics
 	{
 		std::to_array<std::tuple<std::string_view, char, std::string_view, char>>
 		({
 #if defined __clang__
-			{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' },
+			{ "e = "sv, ']', "(anonymous namespace)"sv, '(' }, { "T = "sv, ']', "(anonymous namespace)"sv, '(' },
 #elif defined __GNUC__
-			{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' },
+			{ "e = "sv, ';', "<unnamed>"sv, '<' }, { "T = "sv, ']', "{anonymous}"sv, '{' },
 #elif defined _MSC_VER
-			{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
-			{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
-			{ "", '\0', "struct ", '\0' },
+			{ "epeek<"sv, '>', "`anonymous-namespace'"sv, '`' }, { "::tpeek"sv, '<', "enum `anonymous namespace'::"sv, '\0' },
+			{ ""sv, '\0', "`anonymous namespace'::"sv, '\0' }, { ""sv, '\0', "enum "sv, '\0' }, { ""sv, '\0', "class "sv, '\0' },
+			{ ""sv, '\0', "struct "sv, '\0' },
 #else
 # error "conjure_enum not supported by your compiler"
 #endif
 		})
 	};
-	*/
-
-#if defined __clang__
-	static constexpr std::array<std::tuple<std::string_view, char, std::string_view, char>, 2> _specifics
-	{
-		{{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' }},
-	};
-#elif defined __GNUC__
-	static constexpr std::array<std::tuple<std::string_view, char, std::string_view, char>, 2> _specifics
-	{
-		{{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' }},
-	};
-#elif defined _MSC_VER
-	static constexpr std::array<std::tuple<std::string_view, char, std::string_view, char>, 6> _specifics
-	{
-		{{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
-		{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
-		{ "", '\0', "struct ", '\0' }},
-	};
-#else
-# error "conjure_enum not supported by your compiler"
-#endif
 
 public:
 	enum class stype { enum_t, type_t, extype_t0, extype_t1, extype_t2, extype_t3 };

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -339,19 +339,17 @@ public:
 	}
 	static constexpr std::optional<T> int_to_enum(int value) noexcept
 	{
-		if (const auto result { std::equal_range(values.cbegin(), values.cend(), static_cast<T>(value), _value_comp) };
-			result.first != result.second)
-				return *result.first;
+		if (const auto [begin,end] { std::equal_range(values.cbegin(), values.cend(), static_cast<T>(value), _value_comp) };
+			begin != end)
+				return *begin;
 		return {};
 	}
 
 	// index
 	static constexpr std::optional<size_t> index(T value) noexcept
 	{
-		if (const auto result { std::equal_range(values.cbegin(), values.cend(), value, _value_comp) };
-			result.first != result.second)
-				return &*result.first - &*values.cbegin();
-		return {};
+		const auto [begin,end] { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
+		return begin != end ? &*begin - &*entries.cbegin() : std::optional<size_t>{};
 	}
 	template<T e>
 	static constexpr std::optional<size_t> index() noexcept { return index(e); }
@@ -387,9 +385,8 @@ public:
 	}
 	static constexpr std::optional<T> string_to_enum(std::string_view str) noexcept
 	{
-		if (const auto [begin,end] { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) }; begin != end)
-			return std::get<T>(*begin);
-		return {};
+		const auto [begin,end] { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
+		return begin != end ? std::get<T>(*begin) : std::optional<T>{};
 	}
 
 	// public constexpr data structures

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -297,19 +297,15 @@ private:
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
-		return pl < pr;
+		return static_cast<int>(pl) < static_cast<int>(pr);
 	}
 	static constexpr bool _tuple_comp(const enum_tuple& pl, const enum_tuple& pr) noexcept
 	{
-		const auto& [l1,l2] { pl };
-		const auto& [r1,r2] { pr };
-		return l1 < r1;
+		return static_cast<int>(std::get<T>(pl)) < static_cast<int>(std::get<T>(pr));
 	}
 	static constexpr bool _tuple_comp_rev(const enum_tuple& pl, const enum_tuple& pr) noexcept
 	{
-		const auto& [l1,l2] { pl };
-		const auto& [r1,r2] { pr };
-		return l2 < r2;
+		return std::get<std::string_view>(pl) < std::get<std::string_view>(pr);
 	}
 
 public:

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -339,7 +339,11 @@ public:
 	}
 	static constexpr std::optional<T> int_to_enum(int value) noexcept
 	{
-		return contains(static_cast<T>(value)) ? static_cast<T>(value) : std::optional<T>{};
+		return contains(enum_cast(value)) ? enum_cast(value) : std::optional<T>{};
+	}
+	static constexpr T enum_cast(int value) noexcept
+	{
+		return static_cast<T>(value);
 	}
 
 	// index

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -281,19 +281,6 @@ private:
 	template<T e>
 	static constexpr auto _enum_name_v { fixed_string<_get_name_v<e>.size()>(_get_name_v<e>) };
 
-	template<std::size_t... I>
-	static constexpr auto _entries(std::index_sequence<I...>) noexcept
-	{
-		return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};
-	}
-
-	static constexpr auto _sorted_entries() noexcept
-	{
-		auto tmp { entries };
-		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
-		return tmp;
-	}
-
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
@@ -391,8 +378,15 @@ public:
 
 	// public constexpr data structures
 	static constexpr auto values { _values(std::make_index_sequence<enum_max_value - enum_min_value + 1>()) };
-	static constexpr auto entries { _entries(std::make_index_sequence<values.size()>()) };
-	static constexpr auto sorted_entries { _sorted_entries() };
+	static constexpr auto entries { []<std::size_t... I>(std::index_sequence<I...>) noexcept
+		{ return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};}(std::make_index_sequence<values.size()>()) };
+	static constexpr auto sorted_entries { []() noexcept
+	{
+		auto tmp { entries };
+		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
+		return tmp;
+	}()};
+
 
 	// misc
 	static constexpr int get_enum_min_value() noexcept { return enum_min_value; }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -212,22 +212,22 @@ private:
 		if constexpr (constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::enum_t>()) }; ep == std::string_view::npos)
 			return false;
 #if defined __clang__
-#if not defined FIX8_CONJURE_ENUM_MINIMAL
 		else if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == '(')
 		{
 			if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
+#if not defined FIX8_CONJURE_ENUM_MINIMAL
 			if constexpr (constexpr auto lstr { from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
+#endif
 					return true;
 		}
-#endif
 		else if constexpr (from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).find_first_of(cs::get_spec<sval::end,stype::enum_t>()) != std::string_view::npos)
 			return true;
 		return false;
 #else
 		else if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] != '('
-			&& from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).find_first_of(cs::get_spec<sval::end,stype::enum_t>()) != std::string_view::npos)
+			&& from.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 				return true;
 		else
 			return false;
@@ -344,13 +344,11 @@ public:
 	// contains
 	static constexpr bool contains(T value) noexcept
 	{
-		const auto result { std::equal_range(values.cbegin(), values.cend(), value, _value_comp) };
-		return result.first != result.second;
+		return std::binary_search(values.cbegin(), values.cend(), value, _value_comp);
    }
 	static constexpr bool contains(std::string_view str) noexcept
 	{
-		const auto result { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
-		return result.first != result.second;
+		return std::binary_search(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev);
 	}
 	template<T e>
 	static constexpr bool contains() noexcept { return contains(e); }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -281,19 +281,6 @@ private:
 	template<T e>
 	static constexpr auto _enum_name_v { fixed_string<_get_name_v<e>.size()>(_get_name_v<e>) };
 
-	template<std::size_t... I>
-	static constexpr auto _entries(std::index_sequence<I...>) noexcept
-	{
-		return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};
-	}
-
-	static constexpr auto _sorted_entries() noexcept
-	{
-		auto tmp { entries };
-		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
-		return tmp;
-	}
-
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
@@ -391,8 +378,10 @@ public:
 
 	// public constexpr data structures
 	static constexpr auto values { _values(std::make_index_sequence<enum_max_value - enum_min_value + 1>()) };
-	static constexpr auto entries { _entries(std::make_index_sequence<values.size()>()) };
-	static constexpr auto sorted_entries { _sorted_entries() };
+	static constexpr auto entries { []<std::size_t... I>(std::index_sequence<I...>) noexcept
+		{ return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};}(std::make_index_sequence<values.size()>()) };
+	static constexpr auto sorted_entries { []() noexcept
+		{ auto tmp { entries }; std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev); return tmp; }()};
 
 	// misc
 	static constexpr int get_enum_min_value() noexcept { return enum_min_value; }

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -163,7 +163,7 @@ struct enum_range final : public static_only
 // Convenience macros for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_RANGE_INTS(ec,minv,maxv) \
-	template<> struct FIX8::enum_range<ec> : public static_only { static constexpr int min{minv}, max{maxv}; };
+	template<> struct FIX8::enum_range<ec> { static constexpr int min{minv}, max{maxv}; };
 
 #define FIX8_CONJURE_ENUM_SET_RANGE(minv,maxv) \
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
@@ -181,7 +181,7 @@ struct enum_flags final : public static_only
 // Convenience macro for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> : public static_only { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
+	template<> struct FIX8::enum_flags<ec> { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -189,16 +189,6 @@ public:
 	static consteval const char *epeek() noexcept { return std::source_location::current().function_name(); }
 
 private:
-	template<T e>
-	static constexpr auto _enum_name() noexcept
-	{
-		constexpr auto result { _get_name<e>() };
-		return fixed_string<result.size()>(result);
-	}
-
-	template<T e>
-	static constexpr auto _enum_name_v { _enum_name<e>() };
-
 	template<std::size_t... I>
 	static constexpr auto _entries(std::index_sequence<I...>) noexcept
 	{
@@ -275,12 +265,18 @@ private:
 					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
-		//constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-		if constexpr (constexpr auto lc { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-			return _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).substr(0, lc);
+		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+			return result.substr(0, lc);
 		else
 			return {};
 	}
+
+	template<T e>
+	static constexpr auto _get_name_v { _get_name<e>() };
+
+	template<T e>
+	static constexpr auto _enum_name_v { fixed_string<_get_name_v<e>.size()>(_get_name_v<e>) };
 
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
@@ -358,7 +354,7 @@ public:
 
 	// string <==> enum
 	template<T e>
-	static constexpr std::string_view enum_to_string() noexcept { return _get_name<e>(); }
+	static constexpr std::string_view enum_to_string() noexcept { return _get_name_v<e>; }
 
 	static constexpr std::string_view enum_to_string(T value, [[maybe_unused]] bool noscope=false) noexcept
 	{

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -74,7 +74,7 @@ class fixed_string final
 {
 	std::array<char, N + 1> _buff;
 	template<char... C>
-	constexpr fixed_string(std::string_view sv, std::integer_sequence<char, C...>) noexcept : _buff{sv[C]..., 0} {}
+	constexpr fixed_string(const char *pp, std::integer_sequence<char, C...>) noexcept : _buff{*(pp + C)..., 0} {}
 
 public:
 	explicit constexpr fixed_string(std::string_view sv) noexcept : fixed_string{sv.data(), std::make_integer_sequence<char, N>{}} {}

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -55,8 +55,6 @@
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
 
-using namespace std::literals::string_view_literals;
-
 //-----------------------------------------------------------------------------------------
 // global default enum range
 //-----------------------------------------------------------------------------------------
@@ -111,13 +109,13 @@ class cs final : public static_only
 		std::to_array<std::tuple<std::string_view, char, std::string_view, char>>
 		({
 #if defined __clang__
-			{ "e = "sv, ']', "(anonymous namespace)"sv, '(' }, { "T = "sv, ']', "(anonymous namespace)"sv, '(' },
+			{ "e = ", ']', "(anonymous namespace)", '(' }, { "T = ", ']', "(anonymous namespace)", '(' },
 #elif defined __GNUC__
-			{ "e = "sv, ';', "<unnamed>"sv, '<' }, { "T = "sv, ']', "{anonymous}"sv, '{' },
+			{ "e = ", ';', "<unnamed>", '<' }, { "T = ", ']', "{anonymous}", '{' },
 #elif defined _MSC_VER
-			{ "epeek<"sv, '>', "`anonymous-namespace'"sv, '`' }, { "::tpeek"sv, '<', "enum `anonymous namespace'::"sv, '\0' },
-			{ ""sv, '\0', "`anonymous namespace'::"sv, '\0' }, { ""sv, '\0', "enum "sv, '\0' }, { ""sv, '\0', "class "sv, '\0' },
-			{ ""sv, '\0', "struct "sv, '\0' },
+			{ "epeek<", '>', "`anonymous-namespace'", '`' }, { "::tpeek", '<', "enum `anonymous namespace'::", '\0' },
+			{ "", '\0', "`anonymous namespace'::", '\0' }, { "", '\0', "enum ", '\0' }, { "", '\0', "class ", '\0' },
+			{ "", '\0', "struct ", '\0' },
 #else
 # error "conjure_enum not supported by your compiler"
 #endif
@@ -180,7 +178,7 @@ struct enum_flags final : public static_only
 };
 
 //-----------------------------------------------------------------------------------------
-// Convenience macros for above
+// Convenience macro for above
 //-----------------------------------------------------------------------------------------
 #define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
 	template<> struct FIX8::enum_flags<ec> { static constexpr int is_continuous{iscont}, no_anon{noanon}; };

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -243,6 +243,7 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
+#if not defined FIX8_CONJURE_ENUM_BYPASS
 		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
 		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
 		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
@@ -250,6 +251,9 @@ private:
 		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
 			if (valid[idx])
 				vals[nn++] = static_cast<T>(enum_min_value + idx);
+#else
+		std::array<T, sizeof...(I)> vals{static_cast<T>(enum_min_value + I)... };
+#endif
 		return vals;
 	}
 

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -414,8 +414,8 @@ public:
 	static constexpr int get_enum_max_value() noexcept { return enum_max_value; }
 	static constexpr auto min_v { values.front() };
 	static constexpr auto max_v { values.back() };
-	static constexpr int get_enum_min_actual_value() noexcept { return static_cast<int>(min_v); }
-	static constexpr int get_enum_max_actual_value() noexcept { return static_cast<int>(max_v); }
+	static constexpr int get_actual_enum_min_value() noexcept { return static_cast<int>(min_v); }
+	static constexpr int get_actual_enum_max_value() noexcept { return static_cast<int>(max_v); }
 
 #if not defined FIX8_CONJURE_ENUM_MINIMAL
 #include <fix8/conjure_enum_ext.hpp>

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -41,12 +41,6 @@
 #endif
 
 //----------------------------------------------------------------------------------------
-#include <source_location>
-#include <algorithm>
-#include <string_view>
-#include <tuple>
-#include <concepts>
-#include <optional>
 #if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
 # if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
 #  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
@@ -58,11 +52,18 @@
 #  define FIX8_CONJURE_ENUM_MINIMAL
 # endif
 #endif
+
+//-----------------------------------------------------------------------------------------
+#include <source_location>
+#include <algorithm>
+#include <string_view>
+#include <tuple>
+#include <concepts>
+#include <optional>
+#include <array>
 #if not defined FIX8_CONJURE_ENUM_MINIMAL
 # include <functional>
 #endif
-//#include <cstddef>
-#include <array>
 
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
@@ -213,8 +214,10 @@ private:
 		{
 			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
 			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
 				return true;
+#endif
 		}
 		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
@@ -294,15 +297,19 @@ private:
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
-		return static_cast<int>(pl) < static_cast<int>(pr);
+		return pl < pr;
 	}
 	static constexpr bool _tuple_comp(const enum_tuple& pl, const enum_tuple& pr) noexcept
 	{
-		return static_cast<int>(std::get<T>(pl)) < static_cast<int>(std::get<T>(pr));
+		const auto& [l1,l2] { pl };
+		const auto& [r1,r2] { pr };
+		return l1 < r1;
 	}
 	static constexpr bool _tuple_comp_rev(const enum_tuple& pl, const enum_tuple& pr) noexcept
 	{
-		return std::get<std::string_view>(pl) < std::get<std::string_view>(pr);
+		const auto& [l1,l2] { pl };
+		const auto& [r1,r2] { pr };
+		return l2 < r2;
 	}
 
 public:

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -105,7 +105,7 @@ protected:
 //-----------------------------------------------------------------------------------------
 // compiler specifics
 //-----------------------------------------------------------------------------------------
-class cs : public static_only
+class cs final : public static_only
 {
 	static constexpr auto _specifics
 	{
@@ -157,7 +157,7 @@ concept valid_enum = requires(T)
 // You can specialise this class to define a custom range for your enum
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>
-struct enum_range : public static_only
+struct enum_range final : public static_only
 {
 	static constexpr int min{FIX8_CONJURE_ENUM_MIN_VALUE}, max{FIX8_CONJURE_ENUM_MAX_VALUE};
 };

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -41,6 +41,19 @@
 #endif
 
 //----------------------------------------------------------------------------------------
+#if defined FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS
+# if not defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+#  define FIX8_CONJURE_ENUM_IS_CONTINUOUS
+# endif
+# if not defined FIX8_CONJURE_ENUM_NO_ANON
+#  define FIX8_CONJURE_ENUM_NO_ANON
+# endif
+# if not defined FIX8_CONJURE_ENUM_MINIMAL
+#  define FIX8_CONJURE_ENUM_MINIMAL
+# endif
+#endif
+
+//-----------------------------------------------------------------------------------------
 #include <source_location>
 #include <algorithm>
 #include <string_view>
@@ -171,21 +184,6 @@ struct enum_range final : public static_only
 	FIX8_CONJURE_ENUM_SET_RANGE_INTS(decltype(minv),static_cast<int>(minv), static_cast<int>(maxv))
 
 //-----------------------------------------------------------------------------------------
-// You can specialise this class to define custom flags for your enum
-//-----------------------------------------------------------------------------------------
-template<valid_enum T>
-struct enum_flags final : public static_only
-{
-	static constexpr bool is_continuous{}, no_anon{};
-};
-
-//-----------------------------------------------------------------------------------------
-// Convenience macros for above
-//-----------------------------------------------------------------------------------------
-#define FIX8_CONJURE_ENUM_SET_FLAGS(ec,iscont,noanon) \
-	template<> struct FIX8::enum_flags<ec> { static constexpr int is_continuous{iscont}, no_anon{noanon}; };
-
-//-----------------------------------------------------------------------------------------
 template<valid_enum T>
 class conjure_enum final : public static_only
 {
@@ -216,9 +214,10 @@ private:
 		{
 			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
-			if constexpr (!enum_flags<T>::no_anon)
-				if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
-					return true;
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
+			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
+				return true;
+#endif
 		}
 		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
@@ -235,22 +234,19 @@ private:
 	template<std::size_t... I>
 	static constexpr auto _values(std::index_sequence<I...>) noexcept
 	{
-		if constexpr (enum_flags<T>::is_continuous)
-		{
-			static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
-			return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
-		}
-		else
-		{
-			constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
-			constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
-			static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
-			std::array<T, valid_cnt> vals{};
-			for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
-				if (valid[idx])
-					vals[nn++] = static_cast<T>(enum_min_value + idx);
-			return vals;
-		}
+#if defined FIX8_CONJURE_ENUM_IS_CONTINUOUS
+		static_assert(sizeof...(I) > 0, "conjure_enum requires non-empty enum");
+		return std::array<T, sizeof...(I)>{static_cast<T>(enum_min_value + I)... };
+#else
+		constexpr std::array<bool, sizeof...(I)> valid { _is_valid<static_cast<T>(enum_min_value + I)>()... };
+		constexpr auto valid_cnt { std::count_if(valid.cbegin(), valid.cend(), [](bool val) noexcept { return val; }) };
+		static_assert(valid_cnt > 0, "conjure_enum requires non-empty enum");
+		std::array<T, valid_cnt> vals{};
+		for(std::size_t idx{}, nn{}; nn < valid_cnt; ++idx)
+			if (valid[idx])
+				vals[nn++] = static_cast<T>(enum_min_value + idx);
+		return vals;
+#endif
 	}
 
 	template<T e>
@@ -259,20 +255,19 @@ private:
 		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
-		if constexpr (!enum_flags<T>::no_anon)
+#if not defined FIX8_CONJURE_ENUM_NO_ANON
+		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
 		{
-			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
-			{
 #if defined __clang__
-				if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
-					return {};
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
+				return {};
 #endif
-				if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-					lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
-						if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-							return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
-			}
+			if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
+					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
+#endif
 		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -302,6 +302,9 @@ public:
 		requires !std::convertible_to<T, std::underlying_type_t<T>>;
 	}>{};
 
+	template<T e>
+	static constexpr bool is_valid() noexcept { return _is_valid<e>(); }
+
 	static constexpr auto count() noexcept { return values.size(); }
 
 	// scope ops

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -275,9 +275,9 @@ private:
 					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
-		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
-		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
-			return result.substr(0, lc);
+		//constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+		if constexpr (constexpr auto lc { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
+			return _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()).substr(0, lc);
 		else
 			return {};
 	}

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -216,23 +216,22 @@ private:
 	template<T e>
 	static constexpr bool _is_valid() noexcept
 	{
-		constexpr std::string_view from{_epeek_v<e>};
-		if constexpr (constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::enum_t>()) }; ep == std::string_view::npos)
+		if constexpr (constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) }; ep == std::string_view::npos)
 			return false;
 #if defined __clang__
-		else if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == '(')
+		else if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == '(')
 		{
-			if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == '(')
 				return false;
-			if constexpr (from.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
+			if constexpr (_epeek_v<e>.find(cs::get_spec<sval::anon_str,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)	// is anon
 				return true;
 		}
-		else if constexpr (from.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
+		else if constexpr (_epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 			return true;
 		return false;
 #else
-		else if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] != '('
-			&& from.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
+		else if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] != '('
+			&& _epeek_v<e>.find_first_of(cs::get_spec<sval::end,stype::enum_t>(), ep + cs::get_spec<sval::start,stype::enum_t>().size()) != std::string_view::npos)
 				return true;
 		else
 			return false;
@@ -255,22 +254,21 @@ private:
 	template<T e>
 	static constexpr std::string_view _get_name() noexcept
 	{
-		constexpr std::string_view from{_epeek_v<e>};
-		constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
+		constexpr auto ep { _epeek_v<e>.rfind(cs::get_spec<sval::start,stype::enum_t>()) };
 		if constexpr (ep == std::string_view::npos)
 			return {};
-		if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
+		if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size()] == cs::get_spec<sval::anon_start,stype::enum_t>())
 		{
 #if defined __clang__
-			if constexpr (from[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
+			if constexpr (_epeek_v<e>[ep + cs::get_spec<sval::start,stype::enum_t>().size() + 1] == cs::get_spec<sval::anon_start,stype::enum_t>())
 				return {};
 #endif
-			if (constexpr auto lstr { from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+			if (constexpr auto lstr { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 				lstr.find(cs::get_spec<sval::anon_str,stype::enum_t>()) != std::string_view::npos)	// is anon
 					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 						return lstr.substr(cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::enum_t>().size() + 2)); // eat "::"
 		}
-		constexpr std::string_view result { from.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
+		constexpr std::string_view result { _epeek_v<e>.substr(ep + cs::get_spec<sval::start,stype::enum_t>().size()) };
 		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::enum_t>()) }; lc != std::string_view::npos)
 			return result.substr(0, lc);
 		else

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -181,6 +181,11 @@ public:
 	using enum_tuple = std::tuple<T, std::string_view>;
 	using scoped_tuple = std::tuple<std::string_view, std::string_view>;
 
+	static constexpr const char *tpeek() noexcept { return std::source_location::current().function_name(); }
+
+	template<T e>
+	static constexpr const char *epeek() noexcept { return std::source_location::current().function_name(); }
+
 private:
 	template<T e>
 	static constexpr auto _enum_name() noexcept
@@ -204,6 +209,9 @@ private:
 		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
 		return tmp;
 	}
+
+	template<T e>
+	static constexpr std::string_view _epeek_v { epeek<e>() };
 
 	template<T e>
 	static constexpr bool _is_valid() noexcept
@@ -282,16 +290,6 @@ private:
 	{
 		return std::get<std::string_view>(pl) < std::get<std::string_view>(pr);
 	}
-
-public:
-	static consteval const char *tpeek() noexcept { return std::source_location::current().function_name(); }
-
-	template<T e>
-	static consteval const char *epeek() noexcept { return std::source_location::current().function_name(); }
-
-private:
-	template<T e>
-	static constexpr std::string_view _epeek_v { epeek<e>() };
 
 public:
 	struct is_scoped : std::bool_constant<requires

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -56,6 +56,8 @@
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
 
+using namespace std::literals::string_view_literals;
+
 //-----------------------------------------------------------------------------------------
 // global default enum range
 //-----------------------------------------------------------------------------------------
@@ -103,7 +105,6 @@ protected:
 //-----------------------------------------------------------------------------------------
 // compiler specifics
 //-----------------------------------------------------------------------------------------
-	using namespace std::literals::string_view_literals;
 class cs : public static_only
 {
 	static constexpr auto _specifics
@@ -172,7 +173,7 @@ struct enum_range : public static_only
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>
-class conjure_enum : public static_only
+class conjure_enum final : public static_only
 {
 	static constexpr int enum_min_value{enum_range<T>::min}, enum_max_value{enum_range<T>::max};
 	static_assert(enum_max_value > enum_min_value,

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -189,19 +189,6 @@ public:
 	static consteval const char *epeek() noexcept { return std::source_location::current().function_name(); }
 
 private:
-	template<std::size_t... I>
-	static constexpr auto _entries(std::index_sequence<I...>) noexcept
-	{
-		return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};
-	}
-
-	static constexpr auto _sorted_entries() noexcept
-	{
-		auto tmp { entries };
-		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
-		return tmp;
-	}
-
 	template<T e>
 	static constexpr std::string_view _epeek_v { epeek<e>() };
 
@@ -278,6 +265,19 @@ private:
 	template<T e>
 	static constexpr auto _enum_name_v { fixed_string<_get_name_v<e>.size()>(_get_name_v<e>) };
 
+	template<std::size_t... I>
+	static constexpr auto _entries(std::index_sequence<I...>) noexcept
+	{
+		return std::array<enum_tuple, sizeof...(I)>{{{ values[I], _enum_name_v<values[I]>}...}};
+	}
+
+	static constexpr auto _sorted_entries() noexcept
+	{
+		auto tmp { entries };
+		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
+		return tmp;
+	}
+
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
@@ -299,7 +299,7 @@ public:
 	}>{};
 
 	template<T e>
-	static constexpr bool is_valid() noexcept { return _is_valid<e>(); }
+	static constexpr bool is_valid() noexcept { return contains<e>(); }
 
 	static constexpr auto count() noexcept { return values.size(); }
 

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -68,8 +68,6 @@
 //-----------------------------------------------------------------------------------------
 namespace FIX8 {
 
-using namespace std::literals::string_view_literals;
-
 //-----------------------------------------------------------------------------------------
 // global default enum range
 //-----------------------------------------------------------------------------------------
@@ -196,11 +194,11 @@ public:
 
 //-----------------------------------------------------------------------------------------
 template<valid_enum T>
-class conjure_enum final : public static_only
+class conjure_enum : public static_only
 {
 	static constexpr int enum_min_value{enum_range<T>::min}, enum_max_value{enum_range<T>::max};
 	static_assert(enum_max_value > enum_min_value,
-		"FIX8_CONJURE_ENUM_MAX_VALUE (or enum_range<T>::max) must be greater than FIX8_CONJURE_ENUM_MIN_VALUE (or enum_range<T>::min) ");
+		"FIX8_CONJURE_ENUM_MAX_VALUE, enum_range<T>::max or T::ce_first must be greater than FIX8_CONJURE_ENUM_MIN_VALUE, enum_range<T>::min or T::ce_last) ");
 
 public:
 	using enum_tuple = std::tuple<T, std::string_view>;

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -297,11 +297,11 @@ private:
 	/// comparators
 	static constexpr bool _value_comp(const T& pl, const T& pr) noexcept
 	{
-		return static_cast<int>(pl) < static_cast<int>(pr);
+		return pl < pr;
 	}
 	static constexpr bool _tuple_comp(const enum_tuple& pl, const enum_tuple& pr) noexcept
 	{
-		return static_cast<int>(std::get<T>(pl)) < static_cast<int>(std::get<T>(pr));
+		return std::get<T>(pl) < std::get<T>(pr);
 	}
 	static constexpr bool _tuple_comp_rev(const enum_tuple& pl, const enum_tuple& pr) noexcept
 	{

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -168,11 +168,21 @@ concept valid_enum = requires(T)
 
 //-----------------------------------------------------------------------------------------
 // You can specialise this class to define a custom range for your enum
+// Alternatively, alias T::ce_first as the first and T::ce_last as the last enum in
+// your enum declaration
 //-----------------------------------------------------------------------------------------
-template<valid_enum T>
-struct enum_range final : public static_only
+template<typename T>
+class enum_range final : public static_only
 {
-	static constexpr int min{FIX8_CONJURE_ENUM_MIN_VALUE}, max{FIX8_CONJURE_ENUM_MAX_VALUE};
+	static constexpr int get_first() noexcept requires std::is_enum_v<decltype(T::ce_first)>
+		{ return static_cast<int>(T::ce_first); }
+	static constexpr int get_last() noexcept requires std::is_enum_v<decltype(T::ce_last)>
+		{ return static_cast<int>(T::ce_last); }
+	static constexpr int get_first() noexcept { return FIX8_CONJURE_ENUM_MIN_VALUE; }
+	static constexpr int get_last() noexcept { return FIX8_CONJURE_ENUM_MAX_VALUE; };
+
+public:
+	static constexpr int min{get_first()}, max{get_last()};
 };
 
 //-----------------------------------------------------------------------------------------

--- a/include/fix8/conjure_enum.hpp
+++ b/include/fix8/conjure_enum.hpp
@@ -374,22 +374,21 @@ public:
 
 	static constexpr std::string_view enum_to_string(T value, [[maybe_unused]] bool noscope=false) noexcept
 	{
-		if (const auto result { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
-			result.first != result.second)
+		if (const auto [begin,end] { std::equal_range(entries.cbegin(), entries.cend(), enum_tuple(value, std::string_view()), _tuple_comp) };
+			begin != end)
 		{
 #if not defined FIX8_CONJURE_ENUM_MINIMAL
 			if (noscope)
-				return remove_scope(std::get<std::string_view>(*result.first));
+				return remove_scope(std::get<std::string_view>(*begin));
 #endif
-			return std::get<std::string_view>(*result.first);
+			return std::get<std::string_view>(*begin);
 		}
 		return {};
 	}
 	static constexpr std::optional<T> string_to_enum(std::string_view str) noexcept
 	{
-		if (const auto result { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
-			result.first != result.second)
-				return std::get<T>(*result.first);
+		if (const auto [begin,end] { std::equal_range(sorted_entries.cbegin(), sorted_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) }; begin != end)
+			return std::get<T>(*begin);
 		return {};
 	}
 

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -48,12 +48,14 @@ namespace FIX8 {
 template<typename T>
 concept valid_bitset_enum = valid_enum<T> and requires(T)
 {
-	requires static_cast<std::size_t>(conjure_enum<T>::values.back()) < conjure_enum<T>::count();
+	requires conjure_enum<T>::is_continuous();
+	requires conjure_enum<T>::get_actual_enum_min_value() == 0;
+	requires conjure_enum<T>::get_actual_enum_max_value() < conjure_enum<T>::count();
 };
 
 //-----------------------------------------------------------------------------------------
 // bitset based on supplied enum
-// Note: your enum sequence must be continuous with the last enum value < count of enumerations
+// Note: your enum sequence must be 0 based, continuous and the last enum value < count of enumerations
 //-----------------------------------------------------------------------------------------
 template<valid_bitset_enum T>
 class enum_bitset

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -51,6 +51,7 @@ concept valid_bitset_enum = valid_enum<T> and requires(T)
 	requires conjure_enum<T>::is_continuous();
 	requires conjure_enum<T>::get_actual_enum_min_value() == 0;
 	requires conjure_enum<T>::get_actual_enum_max_value() < conjure_enum<T>::count();
+	requires std::bit_ceil(static_cast<unsigned>(conjure_enum<T>::get_actual_enum_max_value())) >= conjure_enum<T>::count();
 };
 
 //-----------------------------------------------------------------------------------------

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -130,8 +130,8 @@ public:
 	constexpr U to_ulong() const noexcept { return _present; }
 	constexpr unsigned long long to_ullong() const noexcept { return _present; }
 
-	constexpr auto operator[](std::size_t pos) noexcept { return reference(*this, pos); }
-	constexpr auto operator[](std::size_t pos) const noexcept { return const_reference(*this, pos); }
+	constexpr auto operator[](U pos) noexcept { return reference(*this, pos); }
+	constexpr auto operator[](U pos) const noexcept { return const_reference(*this, pos); }
 	constexpr auto operator[](T what) noexcept { return reference(*this, to_underlying(what)); }
 	constexpr auto operator[](T what) const noexcept { return const_reference(*this, to_underlying(what)); }
 

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -8,10 +8,6 @@
 // see https://github.com/fix8mt/conjure_enum
 //
 // Lightweight header-only C++20 enum and typename reflection
-//
-//   Parts based on magic_enum <https://github.com/Neargye/magic_enum>
-//   Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
-//
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -359,6 +355,7 @@ public:
 		return ostr.str();
 	}
 #endif
+	constexpr std::string to_hex_string() const noexcept { return to_hex_string<>(); }
 
 	friend constexpr std::ostream& operator<<(std::ostream& os, const enum_bitset& what) noexcept
 	{

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -140,14 +140,10 @@ public:
 			throw std::overflow_error("overflow");
 		return _present;
 	}
-	constexpr unsigned long long to_ullong() const
-	{
-		if constexpr (countof > 64)
-			throw std::overflow_error("overflow");
-		return _present;
-	}
+	constexpr unsigned long long to_ullong() const noexcept { return _present; }
 	constexpr U get_underlying() const noexcept { return _present; }
 	constexpr int get_underlying_bit_size() const noexcept { return 8 * sizeof(U); }
+	constexpr U get_bit_mask() const noexcept { return all_bits; }
 	constexpr U get_unused_bit_mask() const noexcept { return ((1 << get_underlying_bit_size()) - 1) ^ all_bits; }
 
 	// subscript

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -204,28 +204,28 @@ public:
 	constexpr bool any_of() const noexcept { return (... || test<comp>()); }
 
 	template<std::integral... I>
-	constexpr bool any_of(I...comp) const noexcept { return (... || test(comp)); }
+	constexpr bool any_of(I...comp) const noexcept { return (... || test(U(comp))); }
 
 	template<valid_bitset_enum... E>
-	constexpr bool any_of(E...comp) const noexcept { return (... || test(comp)); }
+	constexpr bool any_of(E...comp) const noexcept { return (... || test(U(comp))); }
 
 	template<T... comp>
 	constexpr bool all_of() const noexcept { return (... && test<comp>()); }
 
 	template<std::integral... I>
-	constexpr bool all_of(I...comp) const noexcept { return (... && test(comp)); }
+	constexpr bool all_of(I...comp) const noexcept { return (... && test(U(comp))); }
 
 	template<valid_bitset_enum... E>
-	constexpr bool all_of(E...comp) const noexcept { return (... && test(comp)); }
+	constexpr bool all_of(E...comp) const noexcept { return (... && test(U(comp))); }
 
 	template<T... comp>
 	constexpr bool none_of() const noexcept { return (... && !test<comp>()); }
 
 	template<std::integral... I>
-	constexpr bool none_of(I...comp) const noexcept { return (... && !test(comp)); }
+	constexpr bool none_of(I...comp) const noexcept { return (... && !test(U(comp))); }
 
 	template<valid_bitset_enum... E>
-	constexpr bool none_of(E...comp) const noexcept { return (... && !test(comp)); }
+	constexpr bool none_of(E...comp) const noexcept { return (... && !test(U(comp))); }
 
 	constexpr bool any() const noexcept { return count(); }
 	constexpr bool all() const noexcept { return _present == all_bits; }

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -72,7 +72,7 @@ class enum_bitset
 	class _reference
 	{
 		R& _owner;
-		std::size_t _idx;
+		U _idx;
 		constexpr _reference(R& obj, std::size_t idx) noexcept : _owner(obj), _idx(idx) {}
 		friend class enum_bitset;
 
@@ -94,7 +94,7 @@ class enum_bitset
 			return *this;
 		}
 
-		constexpr operator bool() const noexcept { return _owner.test(_idx); }
+		constexpr operator bool() const noexcept { return static_cast<bool>(_owner.test(_idx)); }
 	};
 
 	template<T val>

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -8,6 +8,7 @@
 // see https://github.com/fix8mt/conjure_enum
 //
 // Lightweight header-only C++20 enum and typename reflection
+//
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -73,7 +73,7 @@ class enum_bitset
 	{
 		R& _owner;
 		U _idx;
-		constexpr _reference(R& obj, std::size_t idx) noexcept : _owner(obj), _idx(idx) {}
+		constexpr _reference(R& obj, U idx) noexcept : _owner(obj), _idx(idx) {}
 		friend class enum_bitset;
 
 	public:

--- a/include/fix8/conjure_enum_bitset.hpp
+++ b/include/fix8/conjure_enum_bitset.hpp
@@ -1,0 +1,304 @@
+//-----------------------------------------------------------------------------------------
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (C) 2024 Fix8 Market Technologies Pty Ltd
+// SPDX-FileType: SOURCE
+//
+// conjure_enum (header only)
+//   by David L. Dight
+// see https://github.com/fix8mt/conjure_enum
+//
+// Lightweight header-only C++20 enum and typename reflection
+//
+//   Parts based on magic_enum <https://github.com/Neargye/magic_enum>
+//   Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph)
+// shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------------------
+// enum_bitset
+//----------------------------------------------------------------------------------------
+#ifndef FIX8_CONJURE_ENUM_BITSET_HPP_
+#define FIX8_CONJURE_ENUM_BITSET_HPP_
+
+//----------------------------------------------------------------------------------------
+#include <bitset>
+#include <exception>
+#include <bit>
+
+//-----------------------------------------------------------------------------------------
+namespace FIX8 {
+
+//-----------------------------------------------------------------------------------------
+template<typename T>
+concept valid_bitset_enum = valid_enum<T> and requires(T)
+{
+	requires static_cast<std::size_t>(conjure_enum<T>::values.back()) < conjure_enum<T>::count();
+};
+
+//-----------------------------------------------------------------------------------------
+// bitset based on supplied enum
+// Note: your enum sequence must be continuous with the last enum value < count of enumerations
+//-----------------------------------------------------------------------------------------
+template<valid_bitset_enum T>
+class enum_bitset
+{
+	using U = std::underlying_type_t<T>;
+	static constexpr auto countof { conjure_enum<T>::count() };
+
+	template<T val>
+	static constexpr U to_underlying() noexcept { return static_cast<U>(val); } // C++23: upgrade to std::to_underlying
+	static constexpr U to_underlying(T val) noexcept { return static_cast<U>(val); }
+	static constexpr U all_bits { (1 << countof) - 1 };
+	U _present{};
+
+public:
+	explicit constexpr enum_bitset(U bits) noexcept : _present(bits) {}
+	constexpr enum_bitset(std::string_view from, bool anyscope=false, char sep='|', bool ignore_errors=true)
+		: _present(factory(from, anyscope, sep, ignore_errors)) {}
+
+	template<valid_bitset_enum... E>
+	constexpr enum_bitset(E... comp) noexcept : _present((0u | ... | (1 << to_underlying(comp)))) {}
+
+	template<std::integral... I>
+	constexpr enum_bitset(I... comp) noexcept : _present((0u | ... | (1 << comp))) {}
+
+	constexpr enum_bitset() = default;
+	constexpr ~enum_bitset() = default;
+
+	constexpr std::size_t count() const noexcept
+		{ return std::popcount(static_cast<std::make_unsigned_t<U>>(_present)); } // C++23: upgrade to std::bitset when count is constexpr
+	constexpr std::size_t not_count() const noexcept { return countof - count(); }
+	constexpr std::size_t size() const noexcept { return countof; }
+	constexpr U to_ulong() const noexcept { return _present; }
+	constexpr unsigned long long to_ullong() const noexcept { return _present; }
+
+	constexpr bool operator[](std::size_t pos) const noexcept { return test(pos); }
+	constexpr bool operator[](T what) const noexcept { return test(what); }
+
+	/// set
+	constexpr void set(U pos, bool value=true) noexcept { value ? _present |= 1 << pos : _present &= ~(1 << pos); }
+	constexpr void set(T what, bool value=true) noexcept { set(to_underlying(what), value); }
+	constexpr void set() noexcept { _present = all_bits; }
+
+	template<T what>
+	constexpr void set() noexcept
+	{
+		if constexpr (constexpr auto uu{to_underlying<what>()}; uu < countof)
+			_present |= 1 << uu;
+	}
+
+	template<T... comp>
+	requires (sizeof...(comp) > 1)
+	constexpr void set() noexcept { (set<comp>(),...); }
+
+	template<valid_bitset_enum... E>
+	requires (sizeof...(E) > 1)
+	constexpr void set(E... comp) noexcept { return (... | (set(comp))); }
+
+	/// flip
+	template<T what>
+	constexpr void flip() noexcept
+	{
+		if constexpr (constexpr auto uu{to_underlying<what>()}; uu < countof)
+			_present ^= 1 << uu;
+	}
+
+	constexpr void flip() noexcept { _present = ~_present & all_bits; }
+	constexpr void flip(U pos) noexcept { _present ^= 1 << pos; }
+	constexpr void flip(T what) noexcept { flip(to_underlying(what)); }
+
+	/// reset
+	template<T what>
+	constexpr void reset() noexcept
+	{
+		if constexpr (constexpr auto uu{to_underlying<what>()}; uu < countof)
+			_present &= ~(1 << uu);
+	}
+
+	constexpr void reset() noexcept { _present = 0; }
+	constexpr void reset(U pos) noexcept { _present &= ~(1 << pos); }
+	constexpr void reset(T what) noexcept { reset(to_underlying(what)); }
+
+	template<T... comp>
+	requires (sizeof...(comp) > 1)
+	constexpr void reset() noexcept { (reset<comp>(),...); }
+
+	template<std::integral... I>
+	constexpr void reset(I...comp) noexcept { (reset(comp),...); }
+
+	/// test
+	constexpr bool test(U pos) const noexcept { return _present & 1 << pos; }
+	constexpr bool test(T what) const noexcept { return test(to_underlying(what)); }
+	constexpr bool test() const noexcept { return _present; }
+
+	template<T what>
+	constexpr bool test() const noexcept
+	{
+		if constexpr (constexpr auto uu{to_underlying<what>()}; uu < countof)
+			return test(uu);
+		else
+			return false;
+	}
+
+	template<T... comp>
+	constexpr bool any_of() const noexcept { return (... || test<comp>()); }
+
+	template<std::integral... I>
+	constexpr bool any_of(I...comp) const noexcept { return (... || test(comp)); }
+
+	template<valid_bitset_enum... E>
+	constexpr bool any_of(E...comp) const noexcept { return (... || test(comp)); }
+
+	template<T... comp>
+	constexpr bool all_of() const noexcept { return (... && test<comp>()); }
+
+	template<std::integral... I>
+	constexpr bool all_of(I...comp) const noexcept { return (... && test(comp)); }
+
+	template<valid_bitset_enum... E>
+	constexpr bool all_of(E...comp) const noexcept { return (... && test(comp)); }
+
+	template<T... comp>
+	constexpr bool none_of() const noexcept { return (... && !test<comp>()); }
+
+	template<std::integral... I>
+	constexpr bool none_of(I...comp) const noexcept { return (... && !test(comp)); }
+
+	template<valid_bitset_enum... E>
+	constexpr bool none_of(E...comp) const noexcept { return (... && !test(comp)); }
+
+	constexpr bool any() const noexcept { return count(); }
+	constexpr bool all() const noexcept { return _present == all_bits; }
+	constexpr bool none() const noexcept { return !*this; }
+
+	/// operators
+	constexpr operator bool() const noexcept { return count(); }
+	constexpr enum_bitset& operator<<=(std::size_t pos) noexcept { _present <<= pos; return *this; }
+	constexpr enum_bitset& operator>>=(std::size_t pos) noexcept { _present >>= pos; return *this; }
+	constexpr enum_bitset& operator&=(T other) noexcept { _present &= 1 << to_underlying(other); return *this; }
+	constexpr enum_bitset& operator|=(T other) noexcept { _present |= 1 << to_underlying(other); return *this; }
+	constexpr enum_bitset& operator^=(T other) noexcept { _present ^= 1 << to_underlying(other); return *this; }
+	constexpr enum_bitset& operator&=(U other) noexcept { _present &= other; return *this; }
+	constexpr enum_bitset& operator|=(U other) noexcept { _present |= other; return *this; }
+	constexpr enum_bitset& operator^=(U other) noexcept { _present ^= other; return *this; }
+
+	constexpr enum_bitset operator<<(int pos) const noexcept { return enum_bitset(_present << pos); }
+	constexpr enum_bitset operator>>(int pos) const noexcept { return enum_bitset(_present >> pos); }
+	constexpr enum_bitset operator&(T other) const noexcept { return enum_bitset(_present & 1 << to_underlying(other)); }
+	constexpr enum_bitset operator|(T other) const noexcept { return enum_bitset(_present | 1 << to_underlying(other)); }
+	constexpr enum_bitset operator^(T other) const noexcept { return enum_bitset(_present ^ 1 << to_underlying(other)); }
+	constexpr enum_bitset operator&(U other) const noexcept { return enum_bitset(_present & other); }
+	constexpr enum_bitset operator|(U other) const noexcept { return enum_bitset(_present | other); }
+	constexpr enum_bitset operator^(U other) const noexcept { return enum_bitset(_present ^ other); }
+	constexpr enum_bitset operator~() const noexcept { return enum_bitset(~_present & all_bits); }
+
+	/// for_each, for_each_n
+	template<typename Fn, typename... Args>
+	requires std::invocable<Fn&&, T, Args...>
+	[[maybe_unused]] constexpr auto for_each(Fn&& func, Args&&... args) noexcept
+	{
+		return for_each_n(static_cast<int>(countof), std::forward<Fn>(func), std::forward<Args>(args)...);
+	}
+
+	template<typename C, typename Fn, typename... Args> // specialisation for member function with object
+	requires std::invocable<Fn&&, C, T, Args...>
+	[[maybe_unused]] constexpr auto for_each(Fn&& func, C *obj, Args&&... args) noexcept
+	{
+		return for_each(std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...));
+	}
+
+	template<typename Fn, typename... Args>
+	requires std::invocable<Fn&&, T, Args...>
+	[[maybe_unused]] constexpr auto for_each_n(int n, Fn&& func, Args&&... args) noexcept
+	{
+		for (int ii{}, jj{}; ii < static_cast<int>(countof) && jj < n; ++ii)
+			if (const auto ev{conjure_enum<T>::values[ii]}; test(ev))
+				std::invoke(std::forward<Fn>(func), ev, std::forward<Args>(args)...), ++jj;
+		return std::bind(std::forward<Fn>(func), std::placeholders::_1, std::forward<Args>(args)...);
+	}
+
+	template<typename C, typename Fn, typename... Args> // specialisation for member function with object
+	requires std::invocable<Fn&&, C, T, Args...>
+	[[maybe_unused]] constexpr auto for_each_n(int n, Fn&& func, C *obj, Args&&... args) noexcept
+	{
+		return for_each_n(n, std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...));
+	}
+
+	/// create a bitset from custom separated enum string
+	static constexpr U factory(std::string_view src, bool anyscope, char sep, bool ignore_errors)
+	{
+		enum_bitset result;
+		constexpr auto trim([](std::string_view src) noexcept ->auto
+		{
+		   const auto bg(src.find_first_not_of(" \t"));
+			return bg == std::string_view::npos ? src : src.substr(bg, src.find_last_not_of(" \t") - bg + 1);
+		});
+		auto process([anyscope,&result](std::string_view src) noexcept ->auto
+		{
+			if (anyscope && !conjure_enum<T>::has_scope(src))
+				src = conjure_enum<T>::add_scope(src);
+			if (auto ev { conjure_enum<T>::string_to_enum(src) }; ev)
+			{
+				result |= *ev;
+				return true;
+			}
+			return false;
+		});
+		for (std::string_view::size_type pos{}, fnd{};; pos = fnd + 1)
+		{
+			if ((fnd = src.find_first_of(sep, pos)) != std::string_view::npos)
+			{
+				if (auto srcp { trim(src.substr(pos, fnd - pos)) }; !process(trim(srcp)) && !ignore_errors)
+					throw std::invalid_argument(std::string(srcp).c_str());
+				continue;
+			}
+			if (pos < src.size())
+				if (auto srcp { trim(src.substr(pos, src.size() - pos)) }; !process(trim(srcp)) && !ignore_errors)
+					throw std::invalid_argument(std::string(srcp).c_str());
+			break;
+		}
+      return result._present;
+	}
+
+	constexpr std::string to_string(char zero='0', char one='1') const noexcept
+	{
+		return std::bitset<countof>(_present).to_string(zero, one);
+	}
+
+	friend constexpr std::ostream& operator<<(std::ostream& os, const enum_bitset& what) noexcept
+	{
+		return os << what.to_string();
+	}
+};
+
+template<typename T>
+constexpr enum_bitset<T> operator&(const enum_bitset<T>& lh, const enum_bitset<T>& rh) noexcept
+	{ return lh.operator&(rh.to_ulong()); }
+template<typename T>
+constexpr enum_bitset<T> operator|(const enum_bitset<T>& lh, const enum_bitset<T>& rh) noexcept
+	{ return lh.operator|(rh.to_ulong()); }
+template<typename T>
+constexpr enum_bitset<T> operator^(const enum_bitset<T>& lh, const enum_bitset<T>& rh) noexcept
+	{ return lh.operator^(rh.to_ulong()); }
+
+//-----------------------------------------------------------------------------------------
+} // FIX8
+
+#endif // FIX8_CONJURE_ENUM_BITSET_HPP_
+

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -84,9 +84,9 @@ private:
 	static constexpr std::string_view _process_scope([[maybe_unused]] const auto& entr, std::string_view what) noexcept
 	{
 		if constexpr (is_scoped())
-			if (const auto result { std::equal_range(entr.cbegin(), entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
-				result.first != result.second)
-					return std::get<1>(*result.first);
+			if (const auto [begin,end] { std::equal_range(entr.cbegin(), entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
+				begin != end)
+					return std::get<1>(*begin);
 		return what;
 	}
 
@@ -115,10 +115,8 @@ public:
 	static constexpr auto back() noexcept { return *std::prev(cend()); }
 	static constexpr std::optional<T> unscoped_string_to_enum(std::string_view str) noexcept
 	{
-		if (const auto result { std::equal_range(unscoped_entries.cbegin(), unscoped_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
-			result.first != result.second)
-				return std::get<T>(*result.first);
-		return {};
+		const auto [begin,end] { std::equal_range(unscoped_entries.cbegin(), unscoped_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
+		return begin != end ? std::get<T>(*begin) : std::optional<T>{};
 	}
 
 	static constexpr std::string_view type_name() noexcept
@@ -194,24 +192,24 @@ public:
 	requires std::invocable<Fn&&, T, Args...>
 	[[maybe_unused]] static constexpr R dispatch(T ev, R nval, const std::array<std::tuple<T, Fn>, I>& disp, Args&&... args) noexcept
 	{
-		const auto result { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), ev, std::forward<Args>(args)...) : nval;
+		const auto [begin,end] { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return begin != end ? std::invoke(std::get<Fn>(*begin), ev, std::forward<Args>(args)...) : nval;
 	}
 
 	template<std::size_t I, typename R, typename Fn, typename C, typename... Args> // specialisation for member function with not found value(nval) for return
 	requires std::invocable<Fn&&, C, T, Args...>
 	[[maybe_unused]] static constexpr R dispatch(T ev, R nval, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args) noexcept
 	{
-		const auto result { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), obj, ev, std::forward<Args>(args)...) : nval;
+		const auto [begin,end] { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return begin != end ? std::invoke(std::get<Fn>(*begin), obj, ev, std::forward<Args>(args)...) : nval;
 	}
 
 	template<std::size_t I, typename Fn, typename... Args> // void func with not found call to last element
 	requires (std::invocable<Fn&&, T, Args...> && I > 0)
 	static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, Args&&... args) noexcept
 	{
-		const auto result { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), ev, std::forward<Args>(args)...)
+		const auto [begin,end] { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return begin != end ? std::invoke(std::get<Fn>(*begin), ev, std::forward<Args>(args)...)
 														 : std::invoke(std::get<Fn>(*std::prev(disp.cend())), ev, std::forward<Args>(args)...);
 	}
 
@@ -219,8 +217,8 @@ public:
 	requires (std::invocable<Fn&&, C, T, Args...> && I > 0)
 	static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args) noexcept
 	{
-		const auto result { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), obj, ev, std::forward<Args>(args)...)
+		const auto [begin,end] { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return begin != end ? std::invoke(std::get<Fn>(*begin), obj, ev, std::forward<Args>(args)...)
 														 : std::invoke(std::get<Fn>(*std::prev(disp.cend())), obj, ev, std::forward<Args>(args)...);
 	}
 

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -84,10 +84,9 @@ private:
 	static constexpr std::string_view _process_scope([[maybe_unused]] const auto& entr, std::string_view what) noexcept
 	{
 		if constexpr (is_scoped())
-			if (const auto result { std::equal_range(entr.cbegin(),
-				entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
-					result.first != result.second)
-						return std::get<1>(*result.first);
+			if (const auto result { std::equal_range(entr.cbegin(), entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
+				result.first != result.second)
+					return std::get<1>(*result.first);
 		return what;
 	}
 

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -84,9 +84,9 @@ private:
 	static constexpr std::string_view _process_scope([[maybe_unused]] const auto& entr, std::string_view what) noexcept
 	{
 		if constexpr (is_scoped())
-			if (const auto [begin,end] { std::equal_range(entr.cbegin(), entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
-				begin != end)
-					return std::get<1>(*begin);
+			if (const auto result { std::equal_range(entr.cbegin(), entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
+				result.first != result.second)
+					return std::get<1>(*result.first);
 		return what;
 	}
 
@@ -115,8 +115,10 @@ public:
 	static constexpr auto back() noexcept { return *std::prev(cend()); }
 	static constexpr std::optional<T> unscoped_string_to_enum(std::string_view str) noexcept
 	{
-		const auto [begin,end] { std::equal_range(unscoped_entries.cbegin(), unscoped_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
-		return begin != end ? std::get<T>(*begin) : std::optional<T>{};
+		if (const auto result { std::equal_range(unscoped_entries.cbegin(), unscoped_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
+			result.first != result.second)
+				return std::get<T>(*result.first);
+		return {};
 	}
 
 	static constexpr std::string_view type_name() noexcept
@@ -192,24 +194,24 @@ public:
 	requires std::invocable<Fn&&, T, Args...>
 	[[maybe_unused]] static constexpr R dispatch(T ev, R nval, const std::array<std::tuple<T, Fn>, I>& disp, Args&&... args) noexcept
 	{
-		const auto [begin,end] { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return begin != end ? std::invoke(std::get<Fn>(*begin), ev, std::forward<Args>(args)...) : nval;
+		const auto result { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), ev, std::forward<Args>(args)...) : nval;
 	}
 
 	template<std::size_t I, typename R, typename Fn, typename C, typename... Args> // specialisation for member function with not found value(nval) for return
 	requires std::invocable<Fn&&, C, T, Args...>
 	[[maybe_unused]] static constexpr R dispatch(T ev, R nval, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args) noexcept
 	{
-		const auto [begin,end] { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return begin != end ? std::invoke(std::get<Fn>(*begin), obj, ev, std::forward<Args>(args)...) : nval;
+		const auto result { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), obj, ev, std::forward<Args>(args)...) : nval;
 	}
 
 	template<std::size_t I, typename Fn, typename... Args> // void func with not found call to last element
 	requires (std::invocable<Fn&&, T, Args...> && I > 0)
 	static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, Args&&... args) noexcept
 	{
-		const auto [begin,end] { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return begin != end ? std::invoke(std::get<Fn>(*begin), ev, std::forward<Args>(args)...)
+		const auto result { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), ev, std::forward<Args>(args)...)
 														 : std::invoke(std::get<Fn>(*std::prev(disp.cend())), ev, std::forward<Args>(args)...);
 	}
 
@@ -217,8 +219,8 @@ public:
 	requires (std::invocable<Fn&&, C, T, Args...> && I > 0)
 	static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args) noexcept
 	{
-		const auto [begin,end] { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
-		return begin != end ? std::invoke(std::get<Fn>(*begin), obj, ev, std::forward<Args>(args)...)
+		const auto result { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), obj, ev, std::forward<Args>(args)...)
 														 : std::invoke(std::get<Fn>(*std::prev(disp.cend())), obj, ev, std::forward<Args>(args)...);
 	}
 

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -31,7 +31,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //----------------------------------------------------------------------------------------
-// Full build include fragment
+// Full build include fragment; do not include separately
 //----------------------------------------------------------------------------------------
 #ifndef FIX8_CONJURE_ENUM_EXT_HPP_
 #define FIX8_CONJURE_ENUM_EXT_HPP_
@@ -187,7 +187,7 @@ public:
 	template<typename Fn>
 	static constexpr bool tuple_comp(const std::tuple<T, Fn>& pl, const std::tuple<T, Fn>& pr) noexcept
 	{
-		return static_cast<int>(std::get<T>(pl)) < static_cast<int>(std::get<T>(pr));
+		return std::get<T>(pl) < std::get<T>(pr);
 	}
 
 	template<std::size_t I, typename R, typename Fn, typename... Args> // with not found value(nval) for return

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -122,6 +122,33 @@ public:
 		return {};
 	}
 
+	static constexpr std::string_view type_name() noexcept
+	{
+		constexpr std::string_view from{tpeek()};
+#if defined _MSC_VER
+		constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::type_t>()) };
+		if constexpr (ep == std::string_view::npos)
+			return {};
+		if constexpr (constexpr auto lc { from.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
+		{
+			constexpr auto e1 { from.substr(lc + 1, ep - lc - 2) };
+			CHKMSSTR(e1,type_t);
+			CHKMSSTR(e1,extype_t1);
+		}
+		else
+			return {};
+#else
+		if constexpr (constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::type_t>()) }; ep != std::string_view::npos)
+		{
+			constexpr auto result { from.substr(ep + cs::get_spec<sval::start,stype::type_t>().size()) };
+			if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
+				return result.substr(0, lc);
+		}
+		else
+			return {};
+#endif
+	}
+
 	/// for_each, for_each_n
 	template<typename Fn, typename... Args>
 	requires std::invocable<Fn&&, T, Args...>

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -107,9 +107,6 @@ public:
 		return _process_scope(scoped_entries, what);
 	}
 
-	template<T e>
-	static constexpr bool is_valid() noexcept { return _is_valid<e>(); }
-
 	// iterators
 	static constexpr auto cbegin() noexcept { return entries.cbegin(); }
 	static constexpr auto cend() noexcept { return entries.cend(); }

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -223,11 +223,11 @@ public:
 	}
 
 	// public constexpr data structures
-	static constexpr auto names { _names(std::make_index_sequence<values.size()>()) };
-	static constexpr auto scoped_entries { _scoped_entries(std::make_index_sequence<values.size()>()) };
-	static constexpr auto unscoped_entries { _unscoped_entries(std::make_index_sequence<values.size()>()) };
-	static constexpr auto rev_scoped_entries { _rev_scoped_entries(std::make_index_sequence<values.size()>()) };
-	static constexpr auto unscoped_names { _unscoped_names(std::make_index_sequence<values.size()>()) };
+	static constexpr auto names { _names(std::make_index_sequence<count()>()) };
+	static constexpr auto scoped_entries { _scoped_entries(std::make_index_sequence<count()>()) };
+	static constexpr auto unscoped_entries { _unscoped_entries(std::make_index_sequence<count()>()) };
+	static constexpr auto rev_scoped_entries { _rev_scoped_entries(std::make_index_sequence<count()>()) };
+	static constexpr auto unscoped_names { _unscoped_names(std::make_index_sequence<count()>()) };
 };
 
 //-----------------------------------------------------------------------------------------

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -107,6 +107,9 @@ public:
 		return _process_scope(scoped_entries, what);
 	}
 
+	template<T e>
+	static constexpr bool is_valid() noexcept { return _is_valid<e>(); }
+
 	// iterators
 	static constexpr auto cbegin() noexcept { return entries.cbegin(); }
 	static constexpr auto cend() noexcept { return entries.cend(); }

--- a/include/fix8/conjure_enum_ext.hpp
+++ b/include/fix8/conjure_enum_ext.hpp
@@ -1,0 +1,239 @@
+//-----------------------------------------------------------------------------------------
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (C) 2024 Fix8 Market Technologies Pty Ltd
+// SPDX-FileType: SOURCE
+//
+// conjure_enum (header only)
+//   by David L. Dight
+// see https://github.com/fix8mt/conjure_enum
+//
+// Lightweight header-only C++20 enum and typename reflection
+//
+//   Parts based on magic_enum <https://github.com/Neargye/magic_enum>
+//   Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph)
+// shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------------------
+// Full build include fragment
+//----------------------------------------------------------------------------------------
+#ifndef FIX8_CONJURE_ENUM_EXT_HPP_
+#define FIX8_CONJURE_ENUM_EXT_HPP_
+
+//----------------------------------------------------------------------------------------
+private:
+	template<std::size_t... I>
+	static constexpr auto _names(std::index_sequence<I...>) noexcept
+	{
+		return std::array<std::string_view, sizeof...(I)>{{{ _enum_name_v<values[I]>}...}};
+	}
+
+	template<std::size_t... I>
+	static constexpr auto _unscoped_entries(std::index_sequence<I...>) noexcept
+	{
+		std::array<enum_tuple, sizeof...(I)> tmp{{{ values[I], _remove_scope(_enum_name_v<values[I]>)}...}};
+		std::sort(tmp.begin(), tmp.end(), _tuple_comp_rev);
+		return tmp;
+	}
+
+	static constexpr std::string_view _remove_scope(std::string_view what) noexcept
+	{
+		if (const auto lc { what.find_last_of(':') }; lc != std::string_view::npos)
+			return what.substr(lc + 1);
+		return what;
+	}
+
+	template<std::size_t... I>
+	static constexpr auto _scoped_entries(std::index_sequence<I...>) noexcept
+	{
+		std::array<scoped_tuple, sizeof...(I)> tmp{{{ _remove_scope(_enum_name_v<values[I]>), _enum_name_v<values[I]>}...}};
+		std::sort(tmp.begin(), tmp.end(), _scoped_comp);
+		return tmp;
+	}
+
+	template<std::size_t... I>
+	static constexpr auto _rev_scoped_entries(std::index_sequence<I...>) noexcept
+	{
+		std::array<scoped_tuple, sizeof...(I)> tmp{{{ _enum_name_v<values[I]>, _remove_scope(_enum_name_v<values[I]>)}...}};
+		std::sort(tmp.begin(), tmp.end(), _scoped_comp);
+		return tmp;
+	}
+
+	template<std::size_t... I>
+	static constexpr auto _unscoped_names(std::index_sequence<I...>) noexcept
+	{
+		return std::array<std::string_view, sizeof...(I)>{{{ _remove_scope(_enum_name_v<values[I]>)}...}};
+	}
+
+	static constexpr std::string_view _process_scope([[maybe_unused]] const auto& entr, std::string_view what) noexcept
+	{
+		if constexpr (is_scoped())
+			if (const auto result { std::equal_range(entr.cbegin(),
+				entr.cend(), scoped_tuple(what, std::string_view()), _scoped_comp) };
+					result.first != result.second)
+						return std::get<1>(*result.first);
+		return what;
+	}
+
+	static constexpr bool _scoped_comp(const scoped_tuple& pl, const scoped_tuple& pr) noexcept
+	{
+		return std::get<0>(pl) < std::get<0>(pr);
+	}
+
+public:
+	static constexpr std::string_view remove_scope(std::string_view what) noexcept
+	{
+		return _process_scope(rev_scoped_entries, what);
+	}
+
+	static constexpr std::string_view add_scope(std::string_view what) noexcept
+	{
+		return _process_scope(scoped_entries, what);
+	}
+
+	// iterators
+	static constexpr auto cbegin() noexcept { return entries.cbegin(); }
+	static constexpr auto cend() noexcept { return entries.cend(); }
+	static constexpr auto crbegin() noexcept { return entries.crbegin(); }
+	static constexpr auto crend() noexcept { return entries.crend(); }
+	static constexpr auto front() noexcept { return *cbegin(); }
+	static constexpr auto back() noexcept { return *std::prev(cend()); }
+	static constexpr std::optional<T> unscoped_string_to_enum(std::string_view str) noexcept
+	{
+		if (const auto result { std::equal_range(unscoped_entries.cbegin(), unscoped_entries.cend(), enum_tuple(T{}, str), _tuple_comp_rev) };
+			result.first != result.second)
+				return std::get<T>(*result.first);
+		return {};
+	}
+
+	/// for_each, for_each_n
+	template<typename Fn, typename... Args>
+	requires std::invocable<Fn&&, T, Args...>
+	[[maybe_unused]] static constexpr auto for_each(Fn&& func, Args&&... args) noexcept
+	{
+		return for_each_n(static_cast<int>(count()), std::forward<Fn>(func), std::forward<Args>(args)...);
+	}
+
+	template<typename Fn, typename C, typename... Args> // specialisation for member function with object
+	requires std::invocable<Fn&&, C, T, Args...>
+	[[maybe_unused]] static constexpr auto for_each(Fn&& func, C *obj, Args&&... args) noexcept
+	{
+		return for_each(std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...));
+	}
+
+	template<typename Fn, typename... Args>
+	requires std::invocable<Fn&&, T, Args...>
+	[[maybe_unused]] static constexpr auto for_each_n(int n, Fn&& func, Args&&... args) noexcept
+	{
+		for (int ii{}; const auto ev : conjure_enum<T>::values)
+		{
+			if (ii++ >= n)
+				break;
+			std::invoke(std::forward<Fn>(func), ev, std::forward<Args>(args)...);
+		}
+		return std::bind(std::forward<Fn>(func), std::placeholders::_1, std::forward<Args>(args)...);
+	}
+
+	template<typename Fn, typename C, typename... Args> // specialisation for member function with object
+	requires std::invocable<Fn&&, C, T, Args...>
+	[[maybe_unused]] static constexpr auto for_each_n(int n, Fn&& func, C *obj, Args&&... args) noexcept
+	{
+		return for_each_n(n, std::bind(std::forward<Fn>(func), obj, std::placeholders::_1, std::forward<Args>(args)...));
+	}
+
+	// dispatch
+	template<typename Fn>
+	static constexpr bool tuple_comp(const std::tuple<T, Fn>& pl, const std::tuple<T, Fn>& pr) noexcept
+	{
+		return static_cast<int>(std::get<T>(pl)) < static_cast<int>(std::get<T>(pr));
+	}
+
+	template<std::size_t I, typename R, typename Fn, typename... Args> // with not found value(nval) for return
+	requires std::invocable<Fn&&, T, Args...>
+	[[maybe_unused]] static constexpr R dispatch(T ev, R nval, const std::array<std::tuple<T, Fn>, I>& disp, Args&&... args) noexcept
+	{
+		const auto result { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), ev, std::forward<Args>(args)...) : nval;
+	}
+
+	template<std::size_t I, typename R, typename Fn, typename C, typename... Args> // specialisation for member function with not found value(nval) for return
+	requires std::invocable<Fn&&, C, T, Args...>
+	[[maybe_unused]] static constexpr R dispatch(T ev, R nval, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args) noexcept
+	{
+		const auto result { std::equal_range(disp.cbegin(), disp.cend(), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), obj, ev, std::forward<Args>(args)...) : nval;
+	}
+
+	template<std::size_t I, typename Fn, typename... Args> // void func with not found call to last element
+	requires (std::invocable<Fn&&, T, Args...> && I > 0)
+	static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, Args&&... args) noexcept
+	{
+		const auto result { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), ev, std::forward<Args>(args)...)
+														 : std::invoke(std::get<Fn>(*std::prev(disp.cend())), ev, std::forward<Args>(args)...);
+	}
+
+	template<std::size_t I, typename Fn, typename C, typename... Args> // specialisation for void member function with not found call to last element
+	requires (std::invocable<Fn&&, C, T, Args...> && I > 0)
+	static constexpr void dispatch(T ev, const std::array<std::tuple<T, Fn>, I>& disp, C *obj, Args&&... args) noexcept
+	{
+		const auto result { std::equal_range(disp.cbegin(), std::prev(disp.cend()), std::make_tuple(ev, Fn()), tuple_comp<Fn>) };
+		return result.first != result.second ? std::invoke(std::get<Fn>(*result.first), obj, ev, std::forward<Args>(args)...)
+														 : std::invoke(std::get<Fn>(*std::prev(disp.cend())), obj, ev, std::forward<Args>(args)...);
+	}
+
+	// public constexpr data structures
+	static constexpr auto names { _names(std::make_index_sequence<values.size()>()) };
+	static constexpr auto scoped_entries { _scoped_entries(std::make_index_sequence<values.size()>()) };
+	static constexpr auto unscoped_entries { _unscoped_entries(std::make_index_sequence<values.size()>()) };
+	static constexpr auto rev_scoped_entries { _rev_scoped_entries(std::make_index_sequence<values.size()>()) };
+	static constexpr auto unscoped_names { _unscoped_names(std::make_index_sequence<values.size()>()) };
+};
+
+//-----------------------------------------------------------------------------------------
+// allow range based for
+template<valid_enum T>
+struct iterator_adaptor
+{
+	constexpr auto begin() noexcept { return conjure_enum<T>::entries.cbegin(); }
+	constexpr auto end() noexcept { return conjure_enum<T>::entries.cend(); }
+};
+
+//-----------------------------------------------------------------------------------------
+#include <ostream>
+
+//-----------------------------------------------------------------------------------------
+// ostream& operator<< for any enum; add the following before using:
+// using ostream_enum_operator::operator<<;
+//-----------------------------------------------------------------------------------------
+namespace ostream_enum_operator
+{
+	template<typename CharT, typename Traits=std::char_traits<CharT>, valid_enum T>
+	constexpr std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, T value) noexcept
+	{
+		if (conjure_enum<T>::contains(value))
+			return os << conjure_enum<T>::enum_to_string(value);
+		return os << conjure_enum<T>::enum_to_underlying(value);
+	}
+}
+
+//-----------------------------------------------------------------------------------------
+
+#endif // FIX8_CONJURE_ENUM_EXT_HPP_
+

--- a/include/fix8/conjure_type.hpp
+++ b/include/fix8/conjure_type.hpp
@@ -1,0 +1,112 @@
+//-----------------------------------------------------------------------------------------
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (C) 2024 Fix8 Market Technologies Pty Ltd
+// SPDX-FileType: SOURCE
+//
+// conjure_enum (header only)
+//   by David L. Dight
+// see https://github.com/fix8mt/conjure_enum
+//
+// Lightweight header-only C++20 enum and typename reflection
+//
+//   Parts based on magic_enum <https://github.com/Neargye/magic_enum>
+//   Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph)
+// shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------------------------
+// conjure_type
+//----------------------------------------------------------------------------------------
+#ifndef FIX8_CONJURE_TYPE_HPP_
+#define FIX8_CONJURE_TYPE_HPP_
+
+//-----------------------------------------------------------------------------------------
+namespace FIX8 {
+
+//-----------------------------------------------------------------------------------------
+// General purpose class allowing you to extract a string representation of any typename.
+// The string will be stored statically by the compiler, so you can use the statically generated value `name` to obtain your type.
+//-----------------------------------------------------------------------------------------
+template<typename T>
+class conjure_type : public static_only
+{
+	static constexpr std::string_view _get_name() noexcept
+	{
+		constexpr std::string_view from{tpeek()};
+#if defined _MSC_VER
+		constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::type_t>()) };
+		if constexpr (ep == std::string_view::npos)
+			return {};
+		if constexpr (constexpr auto lc { from.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
+		{
+			constexpr auto e1 { from.substr(lc + 1, ep - lc - 2) };
+			CHKMSSTR(e1,type_t);
+			CHKMSSTR(e1,extype_t0);
+			CHKMSSTR(e1,extype_t1);
+			CHKMSSTR(e1,extype_t2);
+			CHKMSSTR(e1,extype_t3);
+		}
+		return {};
+	}
+#else
+		constexpr auto ep { from.rfind(cs::get_spec<sval::start,stype::type_t>()) };
+		if constexpr (ep == std::string_view::npos)
+			return {};
+		if constexpr (from[ep + cs::get_spec<sval::start,stype::type_t>().size()] == cs::get_spec<sval::anon_start,stype::type_t>())
+			if (constexpr auto lstr { from.substr(ep + cs::get_spec<sval::start,stype::type_t>().size()) };
+				lstr.find(cs::get_spec<sval::anon_str,stype::type_t>()) != std::string_view::npos)	// is anon
+					if constexpr (constexpr auto lc { lstr.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
+						return lstr.substr(cs::get_spec<sval::anon_str,stype::type_t>().size() + 2, lc - (cs::get_spec<sval::anon_str,stype::type_t>().size() + 2)); // eat "::"
+		constexpr auto result { from.substr(ep + cs::get_spec<sval::start,stype::type_t>().size()) };
+		if constexpr (constexpr auto lc { result.find_first_of(cs::get_spec<sval::end,stype::type_t>()) }; lc != std::string_view::npos)
+			return result.substr(0, lc);
+		return {};
+	}
+	static constexpr auto _type_name() noexcept
+	{
+		constexpr auto result { _get_name() };
+		return fixed_string<result.size()>(result);
+	}
+#endif
+
+public:
+	static consteval const char *tpeek() noexcept { return std::source_location::current().function_name(); }
+	static constexpr auto name
+	{
+#if defined _MSC_VER
+		_get_name()
+#else
+		_type_name()
+#endif
+	};
+	static constexpr std::string_view as_string_view() noexcept
+	{
+#if defined _MSC_VER
+		return name;
+#else
+		return name.get();
+#endif
+	}
+};
+
+//-----------------------------------------------------------------------------------------
+} // FIX8
+
+#endif // FIX8_CONJURE_TYPE_HPP_
+

--- a/include/fix8/conjure_type.hpp
+++ b/include/fix8/conjure_type.hpp
@@ -8,10 +8,6 @@
 // see https://github.com/fix8mt/conjure_enum
 //
 // Lightweight header-only C++20 enum and typename reflection
-//
-//   Parts based on magic_enum <https://github.com/Neargye/magic_enum>
-//   Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
-//
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/include/fix8/conjure_type.hpp
+++ b/include/fix8/conjure_type.hpp
@@ -8,6 +8,7 @@
 // see https://github.com/fix8mt/conjure_enum
 //
 // Lightweight header-only C++20 enum and typename reflection
+//
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/utests/edgetests.cpp
+++ b/utests/edgetests.cpp
@@ -37,14 +37,16 @@
 //-----------------------------------------------------------------------------------------
 class foobat{};
 
+#define ENUMS One, Two, Three, Four, Five, Six, Seven, Eight, Nine
+
 namespace
 {
-	enum class NineEnums : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
-	enum NineEnums1 : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
+	enum class NineEnums : int { ENUMS };
+	enum NineEnums1 : int { ENUMS };
 	namespace TEST1
 	{
-		enum class NineEnums : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
-		enum NineEnums1 : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
+		enum class NineEnums : int { ENUMS };
+		enum NineEnums1 : int { ENUMS };
 		class foo{};
 	}
 	class foo{};
@@ -52,12 +54,12 @@ namespace
 
 namespace TEST
 {
-	enum class NineEnums : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
-	enum NineEnums1 : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
+	enum class NineEnums : int { ENUMS };
+	enum NineEnums1 : int { ENUMS };
 	namespace TEST1
 	{
-		enum class NineEnums : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
-		enum NineEnums1 : int { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
+		enum class NineEnums : int { ENUMS };
+		enum NineEnums1 : int { ENUMS };
 		class foo{};
 	}
 	class foo{};

--- a/utests/edgetests.cpp
+++ b/utests/edgetests.cpp
@@ -31,6 +31,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <string_view>
 #include <fix8/conjure_enum.hpp>
+#include <fix8/conjure_type.hpp>
 
 //-----------------------------------------------------------------------------------------
 class foobat{};

--- a/utests/edgetests.cpp
+++ b/utests/edgetests.cpp
@@ -31,6 +31,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <string_view>
 #include <fix8/conjure_enum.hpp>
+#include <fix8/conjure_enum_bitset.hpp>
 #include <fix8/conjure_type.hpp>
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -665,6 +665,7 @@ TEST_CASE("enum_bitset")
 	REQUIRE(enum_bitset<range_test>().get_underlying_bit_size() == 8);
 	REQUIRE(ec.get_underlying_bit_size() == 16);
 	REQUIRE(ec.get_unused_bit_mask() == 0b111111 << 10);
+	REQUIRE(ec.get_bit_mask() == 0b1111111111);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -73,8 +73,8 @@ TEST_CASE("default range")
 {
 	REQUIRE(conjure_enum<component>::get_enum_min_value() == FIX8_CONJURE_ENUM_MIN_VALUE);
 	REQUIRE(conjure_enum<component>::get_enum_max_value() == FIX8_CONJURE_ENUM_MAX_VALUE);
-	REQUIRE(conjure_enum<component>::get_enum_min_actual_value() == 0);
-	REQUIRE(conjure_enum<component>::get_enum_max_actual_value() == 14);
+	REQUIRE(conjure_enum<component>::get_actual_enum_min_value() == 0);
+	REQUIRE(conjure_enum<component>::get_actual_enum_max_value() == 14);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -90,8 +90,8 @@ TEST_CASE("custom range")
 {
 	REQUIRE(conjure_enum<range_test>::get_enum_min_value() == 0);
 	REQUIRE(conjure_enum<range_test>::get_enum_max_value() == 7);
-	REQUIRE(conjure_enum<range_test>::get_enum_min_value() == conjure_enum<range_test>::get_enum_min_actual_value());
-	REQUIRE(conjure_enum<range_test>::get_enum_max_value() == conjure_enum<range_test>::get_enum_max_actual_value());
+	REQUIRE(conjure_enum<range_test>::get_enum_min_value() == conjure_enum<range_test>::get_actual_enum_min_value());
+	REQUIRE(conjure_enum<range_test>::get_enum_max_value() == conjure_enum<range_test>::get_actual_enum_max_value());
 	REQUIRE(conjure_enum<range_test1>::get_enum_min_value() == 0);
 	REQUIRE(conjure_enum<range_test1>::get_enum_max_value() == 7);
 	REQUIRE(conjure_enum<range_test2>::get_enum_min_value() == 0);

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -254,6 +254,8 @@ TEST_CASE("enum_to_string")
 	REQUIRE(conjure_enum<component>::enum_to_string(static_cast<component>(100)).empty());
 	REQUIRE(conjure_enum<component>::enum_to_string<component::fragment>() == "component::fragment");
 	REQUIRE(conjure_enum<component1>::enum_to_string<component1::fragment>() == "fragment");
+	using enum numbers;
+	REQUIRE(conjure_enum<numbers>::enum_to_string<two>() == "numbers::two");
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -639,7 +639,7 @@ TEST_CASE("enum_bitset")
 	REQUIRE(ec.to_ulong() == 0b0001001010);
 	REQUIRE(ec.to_string('-', '+') == "---+--+-+-"s);
 	REQUIRE(enum_bitset<numbers>(0b0101001010).to_string() == "0101001010"s);
-	REQUIRE(ec.to_hex_string<>() == "0x4a"s);
+	REQUIRE(ec.to_hex_string() == "0x4a"s);
 	REQUIRE(ec.to_hex_string<false>() == "4a"s);
 	REQUIRE(ec.to_hex_string<true, true>() == "0X4A"s);
 

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -63,6 +63,9 @@ TEST_CASE("fixed_string")
 	REQUIRE(f1.get().size() == t1.size()); // fixed_string as string_view
 	REQUIRE(static_cast<std::string_view>(f1) == t1); // fixed_string as string_view
 	REQUIRE(static_cast<std::string_view>(f1).size() == t1.size()); // fixed_string as string_view
+	std::ostringstream ostr;
+	ostr << f1.c_str();
+	REQUIRE(ostr.str() == "The rain in Spain");
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -666,6 +666,13 @@ TEST_CASE("enum_bitset")
 	REQUIRE(ec.get_underlying_bit_size() == 16);
 	REQUIRE(ec.get_unused_bit_mask() == 0b111111 << 10);
 	REQUIRE(ec.get_bit_mask() == 0b1111111111);
+
+	ec.reset();
+	ec.set<numbers::one,numbers::two,numbers::three>();
+	REQUIRE(ec.countl_one() == 0);
+	REQUIRE(ec.countr_zero() == 1);
+	REQUIRE(ec.countr_one() == 0);
+	REQUIRE(ec.countl_zero() == 6);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -711,6 +718,23 @@ TEST_CASE("enum_bitset ops")
 	ed[numbers::two] = true;
 	REQUIRE(ed.test(numbers::two));
 	REQUIRE(ed[2] == true);
+
+	ed.reset();
+	ed.set<numbers::one,numbers::three,numbers::six>();
+	REQUIRE(ed.rotl(1) == enum_bitset<numbers>(numbers::two,numbers::four,numbers::seven));
+	REQUIRE(ed.rotr(1) == enum_bitset<numbers>(numbers::one,numbers::three,numbers::six));
+	REQUIRE(ed.rotr(1) == enum_bitset<numbers>(numbers::nine,numbers::two,numbers::five));
+	REQUIRE(ed.rotl(4) == enum_bitset<numbers>(numbers::eight,numbers::one,numbers::four));
+
+	ed.reset();
+	ed.set<numbers::two>();
+	REQUIRE(ed.has_single_bit());
+	ed.set<numbers::one,numbers::three>();
+	REQUIRE(!ed.has_single_bit());
+
+	REQUIRE(std::hash<enum_bitset<numbers>>{}(ed) == 14);
+
+	REQUIRE(ed == enum_bitset<numbers>(numbers::one,numbers::two,numbers::three));
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -212,6 +212,9 @@ TEST_CASE("contains")
 	REQUIRE(!conjure_enum<component>::contains(static_cast<component>(100)));
 	REQUIRE(conjure_enum<component>::contains("component::path"sv));
 	REQUIRE(conjure_enum<component1>::contains("path"sv));
+	REQUIRE(conjure_enum<component>::contains<component::path>());
+	REQUIRE(conjure_enum<component>::contains<component::test>()); // alias
+	REQUIRE(conjure_enum<component1>::contains<path>());
 }
 
 //-----------------------------------------------------------------------------------------
@@ -302,6 +305,19 @@ TEST_CASE("enum_to_int")
 	REQUIRE(conjure_enum<component1>::enum_to_int(password) == 4);
 	REQUIRE(conjure_enum<component>::enum_to_underlying(component::password) == 4);
 	REQUIRE(conjure_enum<component1>::enum_to_underlying(password) == 4);
+}
+
+//-----------------------------------------------------------------------------------------
+TEST_CASE("index")
+{
+	REQUIRE(conjure_enum<component>::index(component::scheme).value() == 0);
+	REQUIRE(conjure_enum<component>::index(component::password).value() == 4);
+	REQUIRE(conjure_enum<component>::index(component::query).value() == 8);
+	REQUIRE(conjure_enum<component>::index(component(100)).value_or(100) == 100);
+	REQUIRE(conjure_enum<component>::index<component::scheme>().value() == 0);
+	REQUIRE(conjure_enum<component>::index<component::password>().value() == 4);
+	REQUIRE(conjure_enum<component>::index<component::query>().value() == 8);
+	REQUIRE(conjure_enum<component>::index<component(100)>().value_or(100) == 100);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -73,6 +73,8 @@ TEST_CASE("default range")
 {
 	REQUIRE(conjure_enum<component>::get_enum_min_value() == FIX8_CONJURE_ENUM_MIN_VALUE);
 	REQUIRE(conjure_enum<component>::get_enum_max_value() == FIX8_CONJURE_ENUM_MAX_VALUE);
+	REQUIRE(conjure_enum<component>::get_enum_min_actual_value() == 0);
+	REQUIRE(conjure_enum<component>::get_enum_max_actual_value() == 14);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -88,6 +90,8 @@ TEST_CASE("custom range")
 {
 	REQUIRE(conjure_enum<range_test>::get_enum_min_value() == 0);
 	REQUIRE(conjure_enum<range_test>::get_enum_max_value() == 7);
+	REQUIRE(conjure_enum<range_test>::get_enum_min_value() == conjure_enum<range_test>::get_enum_min_actual_value());
+	REQUIRE(conjure_enum<range_test>::get_enum_max_value() == conjure_enum<range_test>::get_enum_max_actual_value());
 	REQUIRE(conjure_enum<range_test1>::get_enum_min_value() == 0);
 	REQUIRE(conjure_enum<range_test1>::get_enum_max_value() == 7);
 	REQUIRE(conjure_enum<range_test2>::get_enum_min_value() == 0);
@@ -111,10 +115,27 @@ TEST_CASE("is_scoped")
 }
 
 //-----------------------------------------------------------------------------------------
+TEST_CASE("is_continuous")
+{
+	REQUIRE(!conjure_enum<component>::is_continuous());
+	REQUIRE(conjure_enum<numbers>::is_continuous());
+}
+
+//-----------------------------------------------------------------------------------------
 TEST_CASE("count")
 {
 	REQUIRE(conjure_enum<component>::count() == 10);
 	REQUIRE(conjure_enum<component1>::count() == 10);
+	REQUIRE(conjure_enum<numbers>::count() == 10);
+}
+
+//-----------------------------------------------------------------------------------------
+TEST_CASE("in_range")
+{
+	REQUIRE(conjure_enum<component>::in_range(component::password));
+	REQUIRE(!conjure_enum<component>::in_range(static_cast<component>(100)));
+	REQUIRE(conjure_enum<numbers>::in_range(numbers::five));
+	REQUIRE(!conjure_enum<numbers>::in_range(static_cast<numbers>(100)));
 }
 
 //-----------------------------------------------------------------------------------------
@@ -220,6 +241,8 @@ TEST_CASE("contains")
 	REQUIRE(conjure_enum<component>::contains<component::path>());
 	REQUIRE(conjure_enum<component>::contains<component::test>()); // alias
 	REQUIRE(conjure_enum<component1>::contains<path>());
+	REQUIRE(conjure_enum<numbers>::contains(numbers::five));
+	REQUIRE(!conjure_enum<numbers>::contains(static_cast<numbers>(100)));
 }
 
 //-----------------------------------------------------------------------------------------
@@ -301,6 +324,8 @@ TEST_CASE("int_to_enum")
 	REQUIRE(conjure_enum<component1>::int_to_enum(4).value() == password);
 	REQUIRE(conjure_enum<component>::int_to_enum(11).value_or(static_cast<component>(100)) == static_cast<component>(100));
 	REQUIRE(conjure_enum<component1>::int_to_enum(11).value_or(static_cast<component1>(100)) == static_cast<component1>(100));
+	REQUIRE(conjure_enum<numbers>::int_to_enum(4).value() == numbers::four);
+	REQUIRE(conjure_enum<numbers>::int_to_enum(11).value_or(static_cast<numbers>(100)) == static_cast<numbers>(100));
 }
 
 //-----------------------------------------------------------------------------------------
@@ -323,6 +348,8 @@ TEST_CASE("index")
 	REQUIRE(conjure_enum<component>::index<component::password>().value() == 4);
 	REQUIRE(conjure_enum<component>::index<component::query>().value() == 8);
 	REQUIRE(conjure_enum<component>::index<component(100)>().value_or(100) == 100);
+	REQUIRE(conjure_enum<numbers>::index<numbers::five>().value() == 5);
+	REQUIRE(conjure_enum<numbers>::index<numbers(100)>().value_or(100) == 100);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -328,6 +328,7 @@ TEST_CASE("int_to_enum")
 	REQUIRE(conjure_enum<component1>::int_to_enum(11).value_or(static_cast<component1>(100)) == static_cast<component1>(100));
 	REQUIRE(conjure_enum<numbers>::int_to_enum(4).value() == numbers::four);
 	REQUIRE(conjure_enum<numbers>::int_to_enum(11).value_or(static_cast<numbers>(100)) == static_cast<numbers>(100));
+	REQUIRE(conjure_enum<numbers>::enum_cast(150) == static_cast<numbers>(150));
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -68,6 +68,7 @@ enum class numbers64 : uint64_t
 	fifty_five, fifty_six, fifty_seven, fifty_eight, fifty_nine,
 	sixty, sixty_one, sixty_two, sixty_three
 };
+enum class reverse_range_test { first=7, second=6, third=5, fourth=4, fifth=3, sixth=2, seventh=1, eighth=0 };
 
 //-----------------------------------------------------------------------------------------
 // run as: ctest --output-on-failure
@@ -93,6 +94,10 @@ TEST_CASE("default range")
 	REQUIRE(conjure_enum<component>::get_enum_max_value() == FIX8_CONJURE_ENUM_MAX_VALUE);
 	REQUIRE(conjure_enum<component>::get_actual_enum_min_value() == 0);
 	REQUIRE(conjure_enum<component>::get_actual_enum_max_value() == 14);
+	REQUIRE(conjure_enum<reverse_range_test>::get_enum_min_value() == FIX8_CONJURE_ENUM_MIN_VALUE);
+	REQUIRE(conjure_enum<reverse_range_test>::get_enum_max_value() == FIX8_CONJURE_ENUM_MAX_VALUE);
+	REQUIRE(conjure_enum<reverse_range_test>::get_actual_enum_min_value() == 0);
+	REQUIRE(conjure_enum<reverse_range_test>::get_actual_enum_max_value() == 7);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -148,6 +153,7 @@ TEST_CASE("is_continuous")
 {
 	REQUIRE(!conjure_enum<component>::is_continuous());
 	REQUIRE(conjure_enum<numbers>::is_continuous());
+	REQUIRE(conjure_enum<reverse_range_test>::is_continuous());
 }
 
 //-----------------------------------------------------------------------------------------
@@ -321,6 +327,10 @@ TEST_CASE("iterators")
 	REQUIRE(std::get<component1>(conjure_enum<component1>::front()) == scheme);
 	REQUIRE(std::get<component1>(conjure_enum<component1>::back()) == fragment);
 	REQUIRE(std::get<component1>(conjure_enum<component1>::back()) == std::get<component1>(*conjure_enum<component1>::crbegin()));
+	REQUIRE(std::get<reverse_range_test>(conjure_enum<reverse_range_test>::front()) == reverse_range_test::eighth);
+	REQUIRE(std::get<reverse_range_test>(conjure_enum<reverse_range_test>::back()) == reverse_range_test::first);
+	REQUIRE(std::get<reverse_range_test>(conjure_enum<reverse_range_test>::front()) == conjure_enum<reverse_range_test>::min_v);
+	REQUIRE(std::get<reverse_range_test>(conjure_enum<reverse_range_test>::back()) == conjure_enum<reverse_range_test>::max_v);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -733,8 +733,6 @@ TEST_CASE("enum_bitset ops")
 	REQUIRE(!ed.has_single_bit());
 
 	REQUIRE(std::hash<enum_bitset<numbers>>{}(ed) == 14);
-
-	REQUIRE(ed == enum_bitset<numbers>(numbers::one,numbers::two,numbers::three));
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -34,6 +34,8 @@
 #include <iostream>
 #include <sstream>
 #include <fix8/conjure_enum.hpp>
+#include <fix8/conjure_enum_bitset.hpp>
+#include <fix8/conjure_type.hpp>
 
 //-----------------------------------------------------------------------------------------
 using namespace FIX8;

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -661,6 +661,10 @@ TEST_CASE("enum_bitset ops")
 	ed[2] = true;
 	REQUIRE(ed.test(numbers::two));
 	REQUIRE(ed[2] == true);
+	ed.reset();
+	ed[numbers::two] = true;
+	REQUIRE(ed.test(numbers::two));
+	REQUIRE(ed[2] == true);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -656,6 +656,11 @@ TEST_CASE("enum_bitset ops")
 	REQUIRE((ed ^ numbers::one).to_ulong()  == 0b010);
 	ed ^= numbers::one;
 	REQUIRE(ed.to_ulong() == 0b010);
+
+	ed.reset();
+	ed[2] = true;
+	REQUIRE(ed.test(numbers::two));
+	REQUIRE(ed[2] == true);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/utests/unittests.cpp
+++ b/utests/unittests.cpp
@@ -57,7 +57,7 @@ enum class range_test2 { first, second, third, fourth, fifth, sixth, seventh, ei
 TEST_CASE("fixed_string")
 {
 	static constexpr std::string_view t1{"The rain in Spain"};
-	fixed_string<t1.size()> f1{t1};
+	constexpr fixed_string<t1.size()> f1{t1};
 	REQUIRE(f1.size() == t1.size() + 1); // fixed_string makes string ASCIIZ
 	REQUIRE(f1[t1.size()] == 0); // test ASCIIZ
 	REQUIRE(f1.get().size() == t1.size()); // fixed_string as string_view


### PR DESCRIPTION
This release adds improvements and changes, including some from user feedback.
- `enum_range` per enum range with various options:
   - specialization of `enum_range` class; convenience macros
   - `T::ce_first` and `T::ce_last`
- benchmarking
- `conjure_enum`, `conjure_type` and `enum_bitset` now in separate includes
- significant improvements in compile times
- selectable compile optimizations, including
   - `FIX8_CONJURE_ENUM_ALL_OPTIMIZATIONS` 
   - `FIX8_CONJURE_ENUM_IS_CONTINUOUS`
   - `FIX8_CONJURE_ENUM_NO_ANON`
   - `FIX8_CONJURE_ENUM_MINIMAL`
- bug fixes
- `conjure_enum` API additions:
   - `is_continuous`
   - `in_range`
   - `index`
   - `enum_cast`
   - `get_enum_min_value`, `get_enum_max_value`
   - `min_v`, `max_v`
   - `get_actual_enum_min_value`, `get_actual_enum_max_value`
- `enum_bitset` API additions:
   - `std::bitset` constructor and conversion
   - `rotl`, `rotr`
   - `has_single_bit`
   - `to_hex_string`
   - `get_underlying`, `get_underlying_bit_size`
   - `get_bit_mask`, `get_unused_bit_mask`
   - specialization for `std::hash`
   - `countl_zero` , `countl_one` , `countr_zero` , `countr_one` 
   - const and non-const subscript operator (set and test)
 - expanded unit tests, edge case tests
 - updated to latest supported compilers
 - updated examples
 - documentation reorganised and expanded